### PR TITLE
Request preimages for External Service when ExternalPreimage invoices are found

### DIFF
--- a/extpreimage/client.go
+++ b/extpreimage/client.go
@@ -1,37 +1,38 @@
 package extpreimage
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"time"
 
-	"google.golang.org/grpc"
 	grpcpool "github.com/processout/grpc-go-pool"
+	"google.golang.org/grpc"
 )
 
 // RPC is an interface implemented by the grpc package
 type RPC interface {
 	Dial(host string, opt grpc.DialOption) (*grpc.ClientConn, error)
 	WithInsecure() grpc.DialOption
-	NewClient(*grpcpool.ClientConn) (ExternalPreimageServiceClient)
+	NewClient(*grpcpool.ClientConn) ExternalPreimageServiceClient
 }
 
 // grpcRpc exposes the methods from the grpc package that we need
 // this allows us to stub out the grpc methods more easily
-type grpcRpc struct {}
+type grpcRpc struct{}
 
 func (r *grpcRpc) Dial(host string, opt grpc.DialOption) (*grpc.ClientConn,
 	error) {
-  return grpc.Dial(host, opt)
+	return grpc.Dial(host, opt)
 }
 
 func (r *grpcRpc) WithInsecure() grpc.DialOption {
-  return grpc.WithInsecure()
+	return grpc.WithInsecure()
 }
 
-func (r *grpcRpc) NewClient(c *grpcpool.ClientConn) (
-	ExternalPreimageServiceClient) {
+func (r *grpcRpc) NewClient(c *grpcpool.ClientConn) ExternalPreimageServiceClient {
 	return NewExternalPreimageServiceClient(c.ClientConn)
 }
 
@@ -43,24 +44,26 @@ func DefaultRPC() RPC {
 // Client is the exposed interface for an extpreimage Client
 type Client interface {
 	connect(context.Context) (ExternalPreimageServiceClient, error)
-	Retrieve(*GetPreimageRequest) (*GetPreimageResponse, error)
+	Retrieve(*PreimageRequest) ([32]byte, error)
 	Stop()
 }
 
 // client is a representation of a client of the external preimage
 // service that implements the Client interface
 type client struct {
-	host string
-	conn *grpc.ClientConn
+	host   string
+	chain  string
+	conn   *grpc.ClientConn
 	client ExternalPreimageServiceClient
-	rpc RPC
-	pool *grpcpool.Pool
+	rpc    RPC
+	pool   *grpcpool.Pool
 }
 
 // connect creates a new ExternalPreimageServiceClient from the connection pool
 func (c *client) connect(ctx context.Context) (ExternalPreimageServiceClient,
 	error) {
-	conn, err := c.pool.Get(ctx); if err != nil {
+	conn, err := c.pool.Get(ctx)
+	if err != nil {
 		return nil, err
 	}
 	return c.rpc.NewClient(conn), nil
@@ -72,13 +75,14 @@ func (c *client) connect(ctx context.Context) (ExternalPreimageServiceClient,
 // after a long period of time.
 // Additionally, Retrieve lazily connects to the External Preimage
 // server.
-func (c *client) Retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
+func (c *client) retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
 	error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, err := c.connect(ctx); if err != nil {
+	client, err := c.connect(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -107,7 +111,71 @@ func (c *client) Retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
 	}
 }
 
-// Stop closes any outstanding grpc connections to allow for a graceful shutdown
+// symbol converts the configured chain to a symbol to differentiate between
+// currencies in the format that ExternalPreimage service expects.
+// LND keeps track based on chainCode, but, as that value is private, we use
+// its string representation to do our conversion.
+func (c *client) symbol() (Symbol, error) {
+	if c.chain == "bitcoin" {
+		return Symbol_BTC, nil
+	}
+
+	if c.chain == "litecoin" {
+		return Symbol_LTC, nil
+	}
+
+	// instantiate an empty symbol so we can pass the correct type back
+	var symbol Symbol
+	return symbol, fmt.Errorf("extpreimage: Invalid chain name: %v", c.chain)
+}
+
+type PreimageRequest struct {
+	PaymentHash [sha256.Size]byte
+	Amount      int64
+	TimeLock    uint32
+	BestHeight  uint32
+}
+
+func (c *client) Retrieve(req *PreimageRequest) ([32]byte, error) {
+	var preimage [32]byte
+
+	symbol, err := c.symbol()
+	if err != nil {
+		return preimage, err
+	}
+
+	rpcReq := &GetPreimageRequest{
+		PaymentHash: req.PaymentHash[:],
+		Amount:      req.Amount,
+		Symbol:      symbol,
+		TimeLock:    int64(req.TimeLock),
+		BestHeight:  int64(req.BestHeight),
+	}
+
+	res, err := c.retrieve(rpcReq)
+	if err != nil {
+		return preimage, err
+	}
+
+	if len(res.PaymentPreimage) != 32 {
+		return preimage, fmt.Errorf("extpreimage: Returned preimage was of length %v, "+
+			"expected %v", len(res.PaymentPreimage), 32)
+	}
+
+	// Since the hash and preimage were stored separately, we need to validate that
+	// this preimage actually matches this hash before returning it to the caller
+	derivedHash := sha256.Sum256(res.PaymentPreimage[:])
+	if !bytes.Equal(derivedHash[:], req.PaymentHash[:]) {
+		return preimage, fmt.Errorf("extpreimage: Returned preimage did not " +
+			"match provided hash")
+	}
+
+	copy(preimage[:], res.PaymentPreimage)
+	return preimage, nil
+}
+
+// Stop closes any outstanding grpc connections to allow for a graceful
+// shutdown
 func (c *client) Stop() {
 	c.pool.Close()
 }
@@ -118,9 +186,10 @@ func newPool(c *client) (*grpcpool.Pool, error) {
 
 	// factory creates new Connections to be used by the pool
 	factory = func() (*grpc.ClientConn, error) {
-		conn, err := c.rpc.Dial(c.host, c.rpc.WithInsecure()); if err != nil {
+		conn, err := c.rpc.Dial(c.host, c.rpc.WithInsecure())
+		if err != nil {
 			return nil, fmt.Errorf("extpreimage: Failed to start gRPC connection: "+
-				"%v",err)
+				"%v", err)
 		}
 		fmt.Printf("extpreimage: Connected to External Preimage Service at %s\n",
 			c.host)
@@ -133,10 +202,14 @@ func newPool(c *client) (*grpcpool.Pool, error) {
 
 // New creates a new instance of an extpreimage Client without initiating
 // a connection, so that we can lazily connect to the host
-func New(RPCImpl RPC, RPCHost string) (Client, error) {
-	c := &client{host: RPCHost, rpc: RPCImpl}
+func New(RPCImpl RPC, RPCHost string, ChainName string) (Client, error) {
+	if ChainName != "bitcoin" && ChainName != "litecoin" {
+		return nil, fmt.Errorf("extpreimage: Invalid chain name: %v", ChainName)
+	}
+	c := &client{host: RPCHost, rpc: RPCImpl, chain: ChainName}
 	var err error
-	c.pool, err = newPool(c); if err != nil {
+	c.pool, err = newPool(c)
+	if err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/extpreimage/client_test.go
+++ b/extpreimage/client_test.go
@@ -1,24 +1,45 @@
 package extpreimage_test
 
 import (
-	"testing"
+	"crypto/sha256"
 	"fmt"
 	"io"
+	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
 	"github.com/lightningnetwork/lnd/extpreimage"
-	"google.golang.org/grpc"
 	grpcpool "github.com/processout/grpc-go-pool"
+	"google.golang.org/grpc"
 )
+
+// rpcMsg implements the gomock.Matcher interface to allow us to EXPECT()
+// specific rpc messages
+type rpcMsg struct {
+	msg proto.Message
+}
+
+func (r *rpcMsg) Matches(msg interface{}) bool {
+	m, ok := msg.(proto.Message)
+	if !ok {
+		return false
+	}
+	return proto.Equal(m, r.msg)
+}
+
+func (r *rpcMsg) String() string {
+	return fmt.Sprintf("is %s", r.msg)
+}
 
 // mockRpc is a mock implementation of extpreimage.RPC
 // that allows us to test behavior without actually making RPC calls
 type mockRpc struct {
-	ctrl *gomock.Controller
-	conn *grpc.ClientConn
+	ctrl     *gomock.Controller
+	conn     *grpc.ClientConn
 	connOpen bool
-	host string
-	stream *MockExternalPreimageService_GetPreimageClient
+	host     string
+	expect   *rpcMsg
+	stream   *MockExternalPreimageService_GetPreimageClient
 }
 
 // Dial records the destination and marks the connection as "open"
@@ -38,21 +59,28 @@ func (r *mockRpc) WithInsecure() grpc.DialOption {
 
 // NewClient returns our mock client from gomock/mockgen
 // and returns the created stream to any calls to GetPreimage
-func (r *mockRpc) NewClient(c *grpcpool.ClientConn) (
-	extpreimage.ExternalPreimageServiceClient) {
+func (r *mockRpc) NewClient(c *grpcpool.ClientConn) extpreimage.ExternalPreimageServiceClient {
+	var expect gomock.Matcher
+
+	if r.expect != nil {
+		expect = r.expect
+	} else {
+		expect = gomock.Any()
+	}
+
 	client := NewMockExternalPreimageServiceClient(r.ctrl)
 
 	// Set expectation on GetPreimage
 	client.EXPECT().GetPreimage(
 		gomock.Any(),
-		gomock.Any(),
+		expect,
 	).Return(r.stream, nil)
 
 	return client
 }
 
 // newMock sets up a new mock client with mock RPC
-func newMock(t *testing.T, host string) (extpreimage.Client, *mockRpc) {
+func newMock(t *testing.T, host string, chain string) (extpreimage.Client, *mockRpc) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -60,21 +88,36 @@ func newMock(t *testing.T, host string) (extpreimage.Client, *mockRpc) {
 	stream := NewMockExternalPreimageService_GetPreimageClient(ctrl)
 
 	rpc := &mockRpc{ctrl: ctrl, stream: stream}
-	client, _ := extpreimage.New(rpc, host)
+	client, _ := extpreimage.New(rpc, host, chain)
 
 	return client, rpc
+}
+
+func makePreimage(input string) [32]byte {
+	var preimage [32]byte
+	inputBytes := []byte(input)
+	copy(preimage[:], inputBytes)
+	return preimage
 }
 
 // TestRetrieveConnects verifies that calling Retrieve will
 // connect to the remote server automatically
 func TestRetrieveConnects(t *testing.T) {
 	host := "mockhost:12345"
-	c, rpc := newMock(t, host)
+	chain := "bitcoin"
+	preimage := makePreimage("fake preimage")
+	hash := sha256.Sum256(preimage[:])
+	msg := &extpreimage.GetPreimageResponse{
+		PaymentPreimage: preimage[:],
+	}
+	c, rpc := newMock(t, host, chain)
 
 	// Set expectation on receiving.
-	rpc.stream.EXPECT().Recv().Return(nil, nil)
+	rpc.stream.EXPECT().Recv().Return(msg, nil)
 
-	req := &extpreimage.GetPreimageRequest{}
+	req := &extpreimage.PreimageRequest{
+		PaymentHash: hash,
+	}
 	_, err := c.Retrieve(req)
 
 	if err != nil {
@@ -90,42 +133,165 @@ func TestRetrieveConnects(t *testing.T) {
 	}
 }
 
+// TestRetrieveFormsValidRequest tests that the GetPreimageRequest
+// is well-formed and reflects the caller's inputs.
+func TestRetrieveFormsValidRequest(t *testing.T) {
+	host := "mockhost:12345"
+	chain := "bitcoin"
+	preimage := makePreimage("fake preimage")
+	hash := sha256.Sum256(preimage[:])
+	amount := int64(3000)
+	timeLock := uint32(10000)
+	bestHeight := uint32(9000)
+	msg := &extpreimage.GetPreimageResponse{
+		PaymentPreimage: preimage[:],
+	}
+
+	c, rpc := newMock(t, host, chain)
+
+	// Set expectation on receiving.
+	rpc.stream.EXPECT().Recv().Return(msg, nil)
+
+	// Set expected request
+	rpc.expect = &rpcMsg{
+		msg: &extpreimage.GetPreimageRequest{
+			PaymentHash: hash[:],
+			Amount:      amount,
+			Symbol:      extpreimage.Symbol_BTC,
+			TimeLock:    int64(timeLock),
+			BestHeight:  int64(bestHeight),
+		},
+	}
+
+	req := &extpreimage.PreimageRequest{
+		PaymentHash: hash,
+		Amount:      amount,
+		TimeLock:    timeLock,
+		BestHeight:  bestHeight,
+	}
+	_, err := c.Retrieve(req)
+
+	if err != nil {
+		t.Fatalf("Got error while retrieving: %v", err)
+	}
+}
+
+// TestRetrieveSuppliesSymbol tests that Retrieve supplies the
+// currency symbol to the external preimage service based on
+// configuration of the extpreimage client.
+func TestRetrieveSuppliesSymbol(t *testing.T) {
+	host := "mockhost:12345"
+	chain := "litecoin"
+	preimage := makePreimage("fake preimage")
+	hash := sha256.Sum256(preimage[:])
+	amount := int64(3000)
+	timeLock := uint32(10000)
+	bestHeight := uint32(9000)
+	msg := &extpreimage.GetPreimageResponse{
+		PaymentPreimage: preimage[:],
+	}
+
+	c, rpc := newMock(t, host, chain)
+
+	// Set expectation on receiving.
+	rpc.stream.EXPECT().Recv().Return(msg, nil)
+
+	// Set expected request
+	rpc.expect = &rpcMsg{
+		msg: &extpreimage.GetPreimageRequest{
+			PaymentHash: hash[:],
+			Amount:      amount,
+			Symbol:      extpreimage.Symbol_LTC,
+			TimeLock:    int64(timeLock),
+			BestHeight:  int64(bestHeight),
+		},
+	}
+
+	req := &extpreimage.PreimageRequest{
+		PaymentHash: hash,
+		Amount:      amount,
+		TimeLock:    timeLock,
+		BestHeight:  bestHeight,
+	}
+	_, err := c.Retrieve(req)
+
+	if err != nil {
+		t.Fatalf("Got error while retrieving: %v", err)
+	}
+}
+
 // TestRetrieveReturnsFirstMessage verifies that as soon as a single
 // response is received from the ExternalPreimageService, it will
 // be returned to the caller
 func TestRetrieveReturnsFirstMessage(t *testing.T) {
 	host := "mockhost:12345"
+	chain := "bitcoin"
+	preimage := makePreimage("fake preimage")
+	hash := sha256.Sum256(preimage[:])
 	msg := &extpreimage.GetPreimageResponse{
-		PaymentPreimage: []byte("fake preimage"),
+		PaymentPreimage: preimage[:],
 	}
-
-	c, rpc := newMock(t, host)
+	c, rpc := newMock(t, host, chain)
 
 	// Set expectation on receiving.
 	rpc.stream.EXPECT().Recv().Return(msg, nil)
 
-	req := &extpreimage.GetPreimageRequest{}
+	req := &extpreimage.PreimageRequest{
+		PaymentHash: hash,
+	}
 	res, err := c.Retrieve(req)
 
 	if err != nil {
 		t.Fatalf("Got error while retrieving: %v", err)
 	}
 
-	if res != msg {
-		t.Fatalf("Expected res of %v, got %v", msg, res)
+	if res != preimage {
+		t.Fatalf("Expected preimage of %v, got %v", preimage, res)
 	}
 }
 
+// TestRetrievesRejectsInvalidPreimages tests that Retrieve will return an
+// error if the external preimage service returns a preimage that does not
+// match the provided hash.
+func TestRetrievesRejectsInvalidPreimages(t *testing.T) {
+	host := "mockhost:12345"
+	chain := "bitcoin"
+	preimage := makePreimage("fake preimage")
+	otherPreimage := makePreimage("another preimage")
+	hash := sha256.Sum256(otherPreimage[:])
+	expectedErr := "extpreimage: Returned preimage did not match provided hash"
+	msg := &extpreimage.GetPreimageResponse{
+		PaymentPreimage: preimage[:],
+	}
+	c, rpc := newMock(t, host, chain)
+
+	// Set expectation on receiving.
+	rpc.stream.EXPECT().Recv().Return(msg, nil)
+
+	req := &extpreimage.PreimageRequest{
+		PaymentHash: hash,
+	}
+	_, err := c.Retrieve(req)
+
+	if (err == nil) || (err.Error() != expectedErr) {
+		t.Fatalf("Expected err of %v, got %v", expectedErr, err)
+	}
+}
+
+// TestRetrieveErrorsOnStreamError tests that Retrieve will return
+// an error to the caller if the stream to the external preimage
+// server encounters an error.
 func TestRetrieveErrorsOnStreamError(t *testing.T) {
 	host := "mockhost:12345"
+	chain := "bitcoin"
 	fakeErr := fmt.Errorf("fake error")
 
-	c, rpc := newMock(t, host)
+	c, rpc := newMock(t, host, chain)
 
 	// Set expectation on receiving.
 	rpc.stream.EXPECT().Recv().Return(nil, fakeErr)
 
-	req := &extpreimage.GetPreimageRequest{}
+	req := &extpreimage.PreimageRequest{}
 	_, err := c.Retrieve(req)
 
 	if err != fakeErr {
@@ -133,19 +299,23 @@ func TestRetrieveErrorsOnStreamError(t *testing.T) {
 	}
 }
 
+// TestRetrieveErrorsOnEarlyClose tests that Retrieve will return an error
+// to the caller if the stream to the external preimage service closes
+// before returning the requested preimage.
 func TestRetrieveErrorsOnEarlyClose(t *testing.T) {
 	host := "mockhost:12345"
-	expectedErr := "ExternalPreimageServiceClient: server closed stream early"
+	chain := "bitcoin"
+	expectedErr := "extpreimage: server closed stream early"
 
-	c, rpc := newMock(t, host)
+	c, rpc := newMock(t, host, chain)
 
 	// Set expectation on receiving.
 	rpc.stream.EXPECT().Recv().Return(nil, io.EOF)
 
-	req := &extpreimage.GetPreimageRequest{}
+	req := &extpreimage.PreimageRequest{}
 	_, err := c.Retrieve(req)
 
-	if err.Error() != expectedErr {
+	if (err == nil) || (err.Error() != expectedErr) {
 		t.Fatalf("Expected err of %v, got %v", expectedErr, err.Error())
 	}
 }

--- a/extpreimage/rpc.proto
+++ b/extpreimage/rpc.proto
@@ -8,18 +8,18 @@ enum Symbol {
 }
 
 message GetPreimageRequest {
- // Hash of the payment for which we want to retrieve the preimage
- bytes payment_hash = 1;
+  // Hash of the payment for which we want to retrieve the preimage
+  bytes payment_hash = 1;
 
- // The amount of the payment, in integer units (e.g. Satoshis)
- int64 amount = 5;
- // Symbol of the amount
- Symbol symbol = 6;
+  // The amount of the payment, in integer units (e.g. Satoshis)
+  int64 amount = 5;
+  // Symbol of the amount
+  Symbol symbol = 6;
 
- // time lock of the payment extended to us
- int64 time_lock = 10;
- // current height of the blockchain
- int64 best_height = 11;
+  // time lock of the payment extended to us
+  int64 time_lock = 10;
+  // current height of the blockchain
+  int64 best_height = 11;
 }
 
 message GetPreimageResponse {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -692,7 +692,13 @@ func (i *mockInvoiceRegistry) AddInvoice(invoice channeldb.Invoice) error {
 	i.Lock()
 	defer i.Unlock()
 
-	rhash := fastsha256.Sum256(invoice.Terms.PaymentPreimage[:])
+	var rhash [sha256.Size]byte
+	if invoice.Terms.ExternalPreimage {
+		rhash = invoice.Terms.PaymentHash
+	} else {
+		rhash = fastsha256.Sum256(invoice.Terms.PaymentPreimage[:])
+	}
+
 	i.invoices[chainhash.Hash(rhash)] = invoice
 
 	return nil

--- a/server.go
+++ b/server.go
@@ -285,10 +285,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	// Set up the External Preimage client if one is set to
 	// allow us to query for preimages from the external service
 	if cfg.Extpreimage.RPCHost != "" {
-		srvrLog.Infof("Creating extpreimage client for %v",
-			cfg.Extpreimage.RPCHost)
+		srvrLog.Infof("Creating extpreimage client for %v on %v",
+			cfg.Extpreimage.RPCHost, registeredChains.PrimaryChain().String())
 		s.extpreimageClient, err = extpreimage.New(extpreimage.DefaultRPC(),
-			cfg.Extpreimage.RPCHost)
+			cfg.Extpreimage.RPCHost, registeredChains.PrimaryChain().String())
 		if err != nil {
 			srvrLog.Errorf("Could not create extpreimageClient: %v", err)
 			return nil, err


### PR DESCRIPTION
### Description
This change updates the behavior of the HTLCSwitch when it is the destination for a given HTLC.

When the invoice associated with the HTLC is marked with ExternalPreimage, the switch uses the extpreimageClient to query the configured External Preimage service for the invoice. Only if the invoice fails to be found in this external service does the settlement fail.

To ensure that we are only settling with valid preimages, the extpreimage client now performs a check that the returned preimage matches the provided hash.

In order to facillitate the Symbol parameter on the external preimage service, the extpreimage client was made a bit thicker to make use of it easier and giving the lnd server the ability to configure the symbol at startup.

This change also makes the extpreimage testing more robust by creating expectations for requests structured in a particular way.

### Review notes
This change introduces a few new testing helpers which are near replicas of the helpers already in LND. This is to contain our changes as much as possible to make this fork easier to maintain.

There are quite a few adds in this change, but the goal is to keep changes in the `extpreimage` package as much as possible, and where they are not limited to that package, keep them as small and contained as possible.