### PR TITLE
Feature - Add LTC simnet configuration to lnd

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -70,6 +70,18 @@ var litecoinMainNetParams = litecoinNetParams{
 	CoinType: keychain.CoinTypeLitecoin,
 }
 
+
+// litecoinSimNetParams contains parameters specific to the simulation test
+// network.
+//
+// NOTE(dannypaz): Current lightning-labs/lnd code does not support
+// siment on ltc, however ltcd has param information for this setup
+var litecoinSimNetParams = litecoinNetParams{
+	Params:   &litecoinCfg.SimNetParams,
+	rpcPort:  "18556",
+	CoinType: keychain.CoinTypeTestnet,
+}
+
 // regTestNetParams contains parameters specific to a local regtest network.
 var regTestNetParams = bitcoinNetParams{
 	Params:   &bitcoinCfg.RegressionNetParams,

--- a/chainparams.go
+++ b/chainparams.go
@@ -70,12 +70,12 @@ var litecoinMainNetParams = litecoinNetParams{
 	CoinType: keychain.CoinTypeLitecoin,
 }
 
-
 // litecoinSimNetParams contains parameters specific to the simulation test
 // network.
 //
 // NOTE(dannypaz): Current lightning-labs/lnd code does not support
 // siment on ltc, however ltcd has param information for this setup
+// see: https://github.com/ltcsuite/ltcd/blob/master/chaincfg/params.go
 var litecoinSimNetParams = litecoinNetParams{
 	Params:   &litecoinCfg.SimNetParams,
 	rpcPort:  "18556",

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -28,8 +28,8 @@ import (
 	"github.com/roasbeef/btcd/rpcclient"
 	"github.com/roasbeef/btcutil"
 	"github.com/roasbeef/btcwallet/chain"
-	"github.com/roasbeef/btcwallet/walletdb"
 	"github.com/roasbeef/btcwallet/wallet"
+	"github.com/roasbeef/btcwallet/walletdb"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -507,7 +507,6 @@ func loadConfig() (*config, error) {
 		// NOTE(dannypaz): Current lightning-labs/lnd code does not
 		// support siment on ltc
 		if cfg.Litecoin.SimNet {
-			str := "%s: simnet mode for litecoin not currently supported"
 			fmt.Printf("%s: Connecting to experimental litecoin simnet\n", funcName)
 		}
 

--- a/config.go
+++ b/config.go
@@ -504,10 +504,13 @@ func loadConfig() (*config, error) {
 			"litecoin.active must be set to 1 (true)", funcName)
 
 	case cfg.Litecoin.Active:
+		// NOTE(dannypaz): Current lightning-labs/lnd code does not
+		// support siment on ltc
 		if cfg.Litecoin.SimNet {
 			str := "%s: simnet mode for litecoin not currently supported"
-			return nil, fmt.Errorf(str, funcName)
+			fmt.Printf("%s: Connecting to experimental litecoin simnet\n", funcName)
 		}
+
 		if cfg.Litecoin.RegTest {
 			str := "%s: regnet mode for litecoin not currently supported"
 			return nil, fmt.Errorf(str, funcName)
@@ -530,6 +533,12 @@ func loadConfig() (*config, error) {
 		if cfg.Litecoin.TestNet3 {
 			numNets++
 			ltcParams = litecoinTestNetParams
+		}
+		// NOTE(dannypaz): Current lightning-labs/lnd code does not
+		// support siment on ltc
+		if cfg.Litecoin.SimNet {
+			numNets++
+			ltcParams = litecoinSimNetParams
 		}
 		if numNets > 1 {
 			str := "%s: The mainnet, testnet, and simnet params " +

--- a/lnd.go
+++ b/lnd.go
@@ -1036,7 +1036,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 			// Don't leave the file open in case the new wallet
 			// could not be created for whatever reason.
 			if err := loader.UnloadWallet(); err != nil {
-				ltndLog.Errorf("Could not unload new " +
+				ltndLog.Errorf("Could not unload new "+
 					"wallet: %v", err)
 			}
 			return nil, err


### PR DESCRIPTION
This PR adds configuration for LTC simnet on LND and removes the error that was thrown for "ltc simnet not supported".

This was tested by funding the relayer. This PR also have `go fmt` changes