### PR TITLE
Feature: Save External Preimages locally after retrieving

### DIFF
--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -581,7 +581,7 @@ func addInvoicePreimage(invoices *bolt.Bucket, invoiceNum []byte,
 
 	// If we already have a preimage we do not want to overwrite it.
 	if !bytes.Equal(zeroPreimage[:], invoice.Terms.PaymentPreimage[:]) {
-		return fmt.Errorf("Attempting to overwrite preimage on ExternalPreimage "+
+		return fmt.Errorf("Attempted to overwrite preimage on ExternalPreimage "+
 			"invoice with: %v", paymentPreimage)
 	}
 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -17,6 +17,10 @@ type InvoiceDatabase interface {
 	// SettleInvoice attempts to mark an invoice corresponding to the
 	// passed payment hash as fully settled.
 	SettleInvoice(chainhash.Hash) error
+
+	// AddInvoicePreimage attempts to add a local preimage to an invoice
+	// that had an external preimage.
+	AddInvoicePreimage(chainhash.Hash, [32]byte) error
 }
 
 // ChannelLink is an interface which represents the subsystem for managing the

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -579,6 +579,10 @@ func TestChannelLinkExternalPreimagePayment(t *testing.T) {
 	if !invoice.Terms.Settled {
 		t.Fatal("alice invoice wasn't settled")
 	}
+	if !bytes.Equal(invoice.Terms.PaymentPreimage[:], preimage[:]) {
+		t.Fatalf("preimage wasn't saved: expected %v, got %v",
+			preimage[:], invoice.Terms.PaymentPreimage[:])
+	}
 
 	if aliceBandwidthBefore-amount != n.aliceChannelLink.Bandwidth() {
 		t.Fatal("alice bandwidth should have decrease on payment " +

--- a/invoiceregistry.go
+++ b/invoiceregistry.go
@@ -161,6 +161,19 @@ func (i *invoiceRegistry) SettleInvoice(rHash chainhash.Hash) error {
 	return nil
 }
 
+// AddInvoicePreimage attempts to add a preimage to an invoice with
+// an external preimage.
+func (i *invoiceRegistry) AddInvoicePreimage(rHash chainhash.Hash,
+	rPreimage [32]byte) error {
+	ltndLog.Debugf("Adding preimage to invoice %x", rHash[:])
+
+	if err := i.cdb.AddInvoicePreimage(rHash, rPreimage); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // notifyClients notifies all currently registered invoice notification clients
 // of a newly added/settled invoice.
 func (i *invoiceRegistry) notifyClients(invoice *channeldb.Invoice, settle bool) {

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -3985,56 +3985,6 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointEve, true)
 }
 
-// testExternalPreimageInvoice tests that invoices with external preimages
-// are created and retrieved correctly
-func testExternalPreimageInvoice(net *lntest.NetworkHarness, t *harnessTest) {
-	// ctxb := context.Background()
-
-	// const paymentAmt = 1000
-	hash := sha256.Sum256(bytes.Repeat([]byte("A"), 32))
-	if len(hash) == 0 {
-		t.Fatalf("fake err")
-	}
-	// invoice := &lnrpc.Invoice{
-	// 	Memo:             "testing",
-	// 	ExternalPreimage: true,
-	// 	RHash:            hash[:],
-	// 	Value:            paymentAmt,
-	// }
-	// invoiceResp, err := net.Bob.AddInvoice(ctxb, invoice)
-	// if err != nil {
-	// 	t.Fatalf("unable to add invoice: %v", err)
-	// }
-	// if !bytes.Equal(invoiceResp.RHash, hash[:]) {
-	// 	t.Fatalf("expected returned hash %v to match passed hash %v",
-	// 		invoiceResp.RHash, hash[:])
-	// }
-
-	// // Bob's invoice should now be found
-	// payHash := &lnrpc.PaymentHash{
-	// 	RHash: invoiceResp.RHash,
-	// }
-	// dbInvoice, err := net.Bob.LookupInvoice(ctxb, payHash)
-	// if err != nil {
-	// 	t.Fatalf("unable to lookup invoice: %v", err)
-	// }
-	// if !dbInvoice.ExternalPreimage {
-	// 	t.Fatalf("bob's invoice should be use an external preimage: %v",
-	// 		spew.Sdump(dbInvoice))
-	// }
-
-	// var zeroPreimage [32]byte
-	// if !bytes.Equal(zeroPreimage[:], dbInvoice.RPreimage) {
-	// 	t.Fatalf("bob's invoice should not have a preimage defined, found: %v",
-	// 		dbInvoice.RPreimage)
-	// }
-
-	// if !bytes.Equal(hash[:], dbInvoice.RHash) {
-	// 	t.Fatalf("expected saved hash %v to match passed hash %v",
-	// 		dbInvoice.RHash, hash[:])
-	// }
-}
-
 // testMultiHopOverPrivateChannels tests that private channels can be used as
 // intermediate hops in a route for payments.
 func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
@@ -10034,10 +9984,6 @@ var testsCases = []*testCase{
 	{
 		name: "single hop invoice",
 		test: testSingleHopInvoice,
-	},
-	{
-		name: "external preimage invoice",
-		test: testExternalPreimageInvoice,
 	},
 	{
 		name: "sphinx replay persistence",


### PR DESCRIPTION
For invoices with External Preimages, the previous behavior was to use the preimage to settle the invoice but not persist it locally. This caused two problems:
1. Duplicate payments to the same invoice required a second call to the external preimage service
2. Users of invoice subscriptions of invoice lookups found a settled invoice without an associated preimage.

This change fixes those issues by saving the external preimage locally once it is retrieved. This simplifies duplicate payment handling, and allows consumers of invoices to treat external preimage invoices as normal invoices once they are settled.

The actual call to `AddInvoicePreimage` is in `htlcswitch` to avoid passing further configuration and state into the `extpreimage` package.

This change also removes an unused integration test for external preimages. Such an integration test will require setting up a grpc server to serve external preimages.