### PR TITLE
Add External Preimage flag to invoices when creating in RPC Server

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2680,10 +2680,17 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		Receipt:        invoice.Receipt,
 		PaymentRequest: []byte(payReqString),
 		Terms: channeldb.ContractTerm{
+			ExternalPreimage: invoice.ExternalPreimage,
 			Value: amtMSat,
 		},
 	}
 	copy(i.Terms.PaymentPreimage[:], paymentPreimage[:])
+
+	// If we are using an external preimage, we need to persist the payment
+	// hash locally so that we can identify incoming payments to this invoice
+	if invoice.ExternalPreimage {
+		copy(i.Terms.PaymentHash[:], rHash[:])
+	}
 
 	rpcsLog.Tracef("[addinvoice] adding new invoice %v",
 		newLogClosure(func() string {


### PR DESCRIPTION
This change fixes a bug where an external preimage flag being set
in the RPC request was not being set on the channeldb Invoice.

This also adds an integration test for adding external preimage
invoices to at least ensure that creating invoices works as
expected.

This still leaves actually executing external preimage invoices
to a future integration test.