### PR TITLE
Fix - LTCD dep changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -242,7 +242,7 @@
     "chaincfg/chainhash",
     "wire"
   ]
-  revision = "cdab10132e8c6e4a3ffd112dba54791946d28906"
+  revision = "01737289d815e0e32c91e55593ba2fbd8d090b2c"
 
 [[projects]]
   name = "github.com/miekg/dns"
@@ -410,6 +410,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b43fe49565e8715fc718ea0ef3535ae2dcc2016c48c84d4a43d9ce4368e07cf9"
+  inputs-digest = "792b929b6cd715676355052f521eec52f01c2eb40eb7ca08e0cce1867d2750ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,10 +51,6 @@
   revision = "ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940"
 
 [[constraint]]
-  name = "github.com/ltcsuite/ltcd"
-  revision = "cdab10132e8c6e4a3ffd112dba54791946d28906"
-
-[[constraint]]
   name = "github.com/miekg/dns"
   revision = "79bfde677fa81ff8d27c4330c35bda075d360641"
 
@@ -125,3 +121,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/ltcsuite/ltcd"
+  revision = "01737289d815e0e32c91e55593ba2fbd8d090b2c"


### PR DESCRIPTION
After committing changes to LTCD, I forgot to edit lnd to use the latest revision for ltcd. This PR fixes the dependency versioning so that lnd will not fail on ltcd regtest