### PR TITLE
FIX - Close grpc pool connections after use

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -253,12 +253,6 @@
   revision = "79bfde677fa81ff8d27c4330c35bda075d360641"
 
 [[projects]]
-  name = "github.com/processout/grpc-go-pool"
-  packages = ["."]
-  revision = "dd880f820cb22b1abcb14d6f98c3812ac05b3758"
-  version = "v1.2.1"
-
-[[projects]]
   branch = "master"
   name = "github.com/rogpeppe/fastuuid"
   packages = ["."]
@@ -410,6 +404,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "792b929b6cd715676355052f521eec52f01c2eb40eb7ca08e0cce1867d2750ef"
+  inputs-digest = "e51c8746f7789d36b892509af8e0a4b7cbfdeb3df1493168bee90c142cba0f2b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/extpreimage/client.go
+++ b/extpreimage/client.go
@@ -87,14 +87,14 @@ func (c *client) retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
 		return nil, err
 	}
 
-	// return the connection to the pool after function has returned
-	defer conn.Close()
-
 	// make the request to the server to open the stream
 	stream, err := client.GetPreimage(ctx, req)
 	if err != nil {
 		return nil, err
 	}
+
+	// return the connection to the pool after the preimage has been returned
+	defer conn.Close()
 
 	for {
 		// receive the next message from the stream

--- a/extpreimage/client.go
+++ b/extpreimage/client.go
@@ -12,9 +12,9 @@ import (
 
 // RPC is an interface implemented by the grpc package
 type RPC interface {
-  Dial(host string, opt grpc.DialOption) (*grpc.ClientConn, error)
-  WithInsecure() grpc.DialOption
-  NewClient(*grpc.ClientConn) ExternalPreimageServiceClient
+	Dial(host string, opt grpc.DialOption) (*grpc.ClientConn, error)
+	WithInsecure() grpc.DialOption
+	NewClient(*grpc.ClientConn) ExternalPreimageServiceClient
 }
 
 // grpcRpc exposes the methods from the grpc package that we need
@@ -22,21 +22,21 @@ type RPC interface {
 type grpcRpc struct{}
 
 func (r *grpcRpc) Dial(host string, opt grpc.DialOption) (*grpc.ClientConn,
-  error) {
-  return grpc.Dial(host, opt)
+	error) {
+	return grpc.Dial(host, opt)
 }
 
 func (r *grpcRpc) WithInsecure() grpc.DialOption {
-  return grpc.WithInsecure()
+	return grpc.WithInsecure()
 }
 
 func (r *grpcRpc) NewClient(c *grpc.ClientConn) ExternalPreimageServiceClient {
-  return NewExternalPreimageServiceClient(c)
+	return NewExternalPreimageServiceClient(c)
 }
 
 // DefaultRPC exposes the default gRPC implementation for consumers
 func DefaultRPC() RPC {
-  return &grpcRpc{}
+	return &grpcRpc{}
 }
 
 // Client is the exposed interface for an extpreimage Client
@@ -49,10 +49,10 @@ type Client interface {
 // client is a representation of a client of the external preimage
 // service that implements the Client interface
 type client struct {
-	host   string
-	chain  string
-	rpc    RPC
-	conn   *grpc.ClientConn
+	host  string
+	chain string
+	rpc   RPC
+	conn  *grpc.ClientConn
 }
 
 // connect creates a new ExternalPreimageServiceClient from an existing
@@ -61,19 +61,19 @@ func (c *client) connect() (ExternalPreimageServiceClient,
 	error) {
 	if c.conn == nil {
 		conn, err := c.rpc.Dial(c.host, c.rpc.WithInsecure())
-	  if err != nil {
-	    return nil, fmt.Errorf("extpreimage: Failed to start gRPC "+
-	    	"connection: %v", err)
-	  }
-	  fmt.Printf("extpreimage: Connected to External Preimage Service at %s\n",
-	    c.host)
-	  c.conn = conn
+		if err != nil {
+			return nil, fmt.Errorf("extpreimage: Failed to start gRPC "+
+				"connection: %v", err)
+		}
+		fmt.Printf("extpreimage: Connected to External Preimage Service at %s\n",
+			c.host)
+		c.conn = conn
 	} else {
 		fmt.Printf("extpreimage: Re-using connection for %s\n",
-	    c.host)
+			c.host)
 	}
 
-  return c.rpc.NewClient(c.conn), nil
+	return c.rpc.NewClient(c.conn), nil
 }
 
 // Retrieve is a wrapper around the underlying GetPreimage defined

--- a/extpreimage/client.go
+++ b/extpreimage/client.go
@@ -6,17 +6,15 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"time"
 
-	grpcpool "github.com/processout/grpc-go-pool"
 	"google.golang.org/grpc"
 )
 
 // RPC is an interface implemented by the grpc package
 type RPC interface {
-	Dial(host string, opt grpc.DialOption) (*grpc.ClientConn, error)
-	WithInsecure() grpc.DialOption
-	NewClient(*grpcpool.ClientConn) ExternalPreimageServiceClient
+  Dial(host string, opt grpc.DialOption) (*grpc.ClientConn, error)
+  WithInsecure() grpc.DialOption
+  NewClient(*grpc.ClientConn) ExternalPreimageServiceClient
 }
 
 // grpcRpc exposes the methods from the grpc package that we need
@@ -24,29 +22,28 @@ type RPC interface {
 type grpcRpc struct{}
 
 func (r *grpcRpc) Dial(host string, opt grpc.DialOption) (*grpc.ClientConn,
-	error) {
-	return grpc.Dial(host, opt)
+  error) {
+  return grpc.Dial(host, opt)
 }
 
 func (r *grpcRpc) WithInsecure() grpc.DialOption {
-	return grpc.WithInsecure()
+  return grpc.WithInsecure()
 }
 
-func (r *grpcRpc) NewClient(c *grpcpool.ClientConn) ExternalPreimageServiceClient {
-	return NewExternalPreimageServiceClient(c.ClientConn)
+func (r *grpcRpc) NewClient(c *grpc.ClientConn) ExternalPreimageServiceClient {
+  return NewExternalPreimageServiceClient(c)
 }
 
 // DefaultRPC exposes the default gRPC implementation for consumers
 func DefaultRPC() RPC {
-	return &grpcRpc{}
+  return &grpcRpc{}
 }
 
 // Client is the exposed interface for an extpreimage Client
 type Client interface {
-	connect(context.Context) (ExternalPreimageServiceClient, *grpcpool.ClientConn,
-		error)
+	connect() (ExternalPreimageServiceClient, error)
 	Retrieve(*PreimageRequest) ([32]byte, error, error)
-	Stop()
+	Stop() error
 }
 
 // client is a representation of a client of the external preimage
@@ -54,20 +51,29 @@ type Client interface {
 type client struct {
 	host   string
 	chain  string
-	conn   *grpc.ClientConn
-	client ExternalPreimageServiceClient
 	rpc    RPC
-	pool   *grpcpool.Pool
+	conn   *grpc.ClientConn
 }
 
-// connect creates a new ExternalPreimageServiceClient from the connection pool
-func (c *client) connect(ctx context.Context) (ExternalPreimageServiceClient,
-	*grpcpool.ClientConn, error) {
-	conn, err := c.pool.Get(ctx)
-	if err != nil {
-		return nil, nil, err
+// connect creates a new ExternalPreimageServiceClient from an existing
+// connection, or it creates a new connection if none exists.
+func (c *client) connect() (ExternalPreimageServiceClient,
+	error) {
+	if c.conn == nil {
+		conn, err := c.rpc.Dial(c.host, c.rpc.WithInsecure())
+	  if err != nil {
+	    return nil, fmt.Errorf("extpreimage: Failed to start gRPC "+
+	    	"connection: %v", err)
+	  }
+	  fmt.Printf("extpreimage: Connected to External Preimage Service at %s\n",
+	    c.host)
+	  c.conn = conn
+	} else {
+		fmt.Printf("extpreimage: Re-using connection for %s\n",
+	    c.host)
 	}
-	return c.rpc.NewClient(conn), conn, nil
+
+  return c.rpc.NewClient(c.conn), nil
 }
 
 // Retrieve is a wrapper around the underlying GetPreimage defined
@@ -82,7 +88,7 @@ func (c *client) retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	client, conn, err := c.connect(ctx)
+	client, err := c.connect()
 	if err != nil {
 		return nil, err
 	}
@@ -92,9 +98,6 @@ func (c *client) retrieve(req *GetPreimageRequest) (*GetPreimageResponse,
 	if err != nil {
 		return nil, err
 	}
-
-	// return the connection to the pool after the preimage has been returned
-	defer conn.Close()
 
 	for {
 		// receive the next message from the stream
@@ -199,28 +202,12 @@ func (c *client) Retrieve(req *PreimageRequest) ([32]byte, error, error) {
 
 // Stop closes any outstanding grpc connections to allow for a graceful
 // shutdown
-func (c *client) Stop() {
-	c.pool.Close()
-}
-
-// newPool creates a new grpc pool of connections for the client to use
-func newPool(c *client) (*grpcpool.Pool, error) {
-	var factory grpcpool.Factory
-
-	// factory creates new Connections to be used by the pool
-	factory = func() (*grpc.ClientConn, error) {
-		conn, err := c.rpc.Dial(c.host, c.rpc.WithInsecure())
-		if err != nil {
-			return nil, fmt.Errorf("extpreimage: Failed to start gRPC connection: "+
-				"%v", err)
-		}
-		fmt.Printf("extpreimage: Connected to External Preimage Service at %s\n",
-			c.host)
-		return conn, err
+func (c *client) Stop() error {
+	if c.conn != nil {
+		return c.conn.Close()
 	}
 
-	// limit the maximum number of connections to the extpreimage server to 5
-	return grpcpool.New(factory, 5, 5, time.Second)
+	return nil
 }
 
 // New creates a new instance of an extpreimage Client without initiating
@@ -230,10 +217,5 @@ func New(RPCImpl RPC, RPCHost string, ChainName string) (Client, error) {
 		return nil, fmt.Errorf("extpreimage: Invalid chain name: %v", ChainName)
 	}
 	c := &client{host: RPCHost, rpc: RPCImpl, chain: ChainName}
-	var err error
-	c.pool, err = newPool(c)
-	if err != nil {
-		return nil, err
-	}
 	return c, nil
 }

--- a/extpreimage/client_test.go
+++ b/extpreimage/client_test.go
@@ -363,7 +363,7 @@ func TestRetrievePermanentErrorsOnPermanentFailure(t *testing.T) {
 	err := "fake error"
 	preimage := makePreimage("fake preimage")
 	hash := sha256.Sum256(preimage[:])
-	expectedErr := "extpreimage: Encountered permanent error from external "+
+	expectedErr := "extpreimage: Encountered permanent error from external " +
 		"service: " + err
 	msg := &extpreimage.GetPreimageResponse{
 		PermanentError: err,

--- a/extpreimage/client_test.go
+++ b/extpreimage/client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/lightningnetwork/lnd/extpreimage"
-	grpcpool "github.com/processout/grpc-go-pool"
 	"google.golang.org/grpc"
 )
 
@@ -59,7 +58,7 @@ func (r *mockRpc) WithInsecure() grpc.DialOption {
 
 // NewClient returns our mock client from gomock/mockgen
 // and returns the created stream to any calls to GetPreimage
-func (r *mockRpc) NewClient(c *grpcpool.ClientConn) extpreimage.ExternalPreimageServiceClient {
+func (r *mockRpc) NewClient(c *grpc.ClientConn) extpreimage.ExternalPreimageServiceClient {
 	var expect gomock.Matcher
 
 	if r.expect != nil {
@@ -111,6 +110,10 @@ func TestRetrieveConnects(t *testing.T) {
 		PaymentPreimage: preimage[:],
 	}
 	c, rpc := newMock(t, host, chain)
+
+	if rpc.connOpen == true {
+		t.Fatalf("Expected conn not to be open, got %v", rpc.connOpen)
+	}
 
 	// Set expectation on receiving.
 	rpc.stream.EXPECT().Recv().Return(msg, nil)

--- a/extpreimage/client_test.go
+++ b/extpreimage/client_test.go
@@ -1,6 +1,7 @@
 package extpreimage_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -69,9 +70,11 @@ func (r *mockRpc) NewClient(c *grpc.ClientConn) extpreimage.ExternalPreimageServ
 
 	client := NewMockExternalPreimageServiceClient(r.ctrl)
 
+	ctx, _ := context.WithCancel(context.Background())
+
 	// Set expectation on GetPreimage
 	client.EXPECT().GetPreimage(
-		gomock.Any(),
+		gomock.Eq(ctx),
 		expect,
 	).Return(r.stream, nil)
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -500,7 +500,7 @@ func TestChannelLinkMultiHopPayment(t *testing.T) {
 // extpreimage.Client interface for testing retrieval of preimages
 type mockExtpreimageClient struct {
 	extpreimage.Client
-	preimage [32]byte
+	preimage  [32]byte
 	permError error
 }
 
@@ -688,7 +688,6 @@ func TestExitNodeExternalPreimagePermanentFail(t *testing.T) {
 			"instead have: %v", err)
 	}
 }
-
 
 // TestExitNodeTimelockPayloadMismatch tests that when an exit node receives an
 // incoming HTLC, if the time lock encoded in the payload of the forwarded HTLC


### PR DESCRIPTION
We were seeing that after every 5th atomic swap, the connection to the interchain router would timeout and we would be unable to perform any market actions until the `maker` had restarted one of their counter currency nodes (in this case, LTC). As a result, users were only able to complete 5 trades before connections would die and a docker restart was required.

We were not properly closing the connections in our connection pool after use and since the connection was used for a stream, the connection never idled and returned to the pool, leaving it open indefinitely.

This PR addresses this issue by defering the closing of a connection until either 1. the retrieval of the preimage is completed or 2. the retrieval of preimage has failed.