### PR TITLE
poll for preimages if LookupPreimage fails

### DIFF
--- a/channeldb/invoice_preimage_test.go
+++ b/channeldb/invoice_preimage_test.go
@@ -1,395 +1,395 @@
 package channeldb_test
 
 import (
-  "bytes"
-  "crypto/rand"
-  "crypto/sha256"
-  "fmt"
-  "testing"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
 
-  "github.com/btcsuite/btcd/chaincfg/chainhash"
-  "github.com/lightningnetwork/lnd/channeldb"
-  "github.com/lightningnetwork/lnd/extpreimage"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/extpreimage"
 )
 
 type mockExtpreimageClient struct {
-  extpreimage.Client
-  expectedRequest *extpreimage.PreimageRequest
-  preimage        [32]byte
-  tempErr         error
-  permErr         error
+	extpreimage.Client
+	expectedRequest *extpreimage.PreimageRequest
+	preimage        [32]byte
+	tempErr         error
+	permErr         error
 }
 
 func (c *mockExtpreimageClient) Retrieve(req *extpreimage.PreimageRequest) (
-  [32]byte, error, error) {
-  var zeroPreimage [32]byte
+	[32]byte, error, error) {
+	var zeroPreimage [32]byte
 
-  // if no expectation is set, just return whatever was passed
-  if c.expectedRequest == nil {
-    return c.preimage, c.tempErr, c.permErr
-  }
+	// if no expectation is set, just return whatever was passed
+	if c.expectedRequest == nil {
+		return c.preimage, c.tempErr, c.permErr
+	}
 
-  if !bytes.Equal(c.expectedRequest.PaymentHash[:], req.PaymentHash[:]) {
-    return zeroPreimage, nil, fmt.Errorf("Wrong PaymentHash: expected %v, "+
-      "got %v", c.expectedRequest.PaymentHash, req.PaymentHash)
-  }
+	if !bytes.Equal(c.expectedRequest.PaymentHash[:], req.PaymentHash[:]) {
+		return zeroPreimage, nil, fmt.Errorf("Wrong PaymentHash: expected %v, "+
+			"got %v", c.expectedRequest.PaymentHash, req.PaymentHash)
+	}
 
-  if c.expectedRequest.Amount != req.Amount {
-    return zeroPreimage, nil, fmt.Errorf("Wrong Amount: expected %v, "+
-      "got %v", c.expectedRequest.Amount, req.Amount)
-  }
+	if c.expectedRequest.Amount != req.Amount {
+		return zeroPreimage, nil, fmt.Errorf("Wrong Amount: expected %v, "+
+			"got %v", c.expectedRequest.Amount, req.Amount)
+	}
 
-  if c.expectedRequest.TimeLock != req.TimeLock {
-    return zeroPreimage, nil, fmt.Errorf("Wrong TimeLock: expected %v, "+
-      "got %v", c.expectedRequest.TimeLock, req.TimeLock)
-  }
+	if c.expectedRequest.TimeLock != req.TimeLock {
+		return zeroPreimage, nil, fmt.Errorf("Wrong TimeLock: expected %v, "+
+			"got %v", c.expectedRequest.TimeLock, req.TimeLock)
+	}
 
-  if c.expectedRequest.BestHeight != req.BestHeight {
-    return zeroPreimage, nil, fmt.Errorf("Wrong BestHeight: expected %v, "+
-      "got %v", c.expectedRequest.BestHeight, req.BestHeight)
-  }
+	if c.expectedRequest.BestHeight != req.BestHeight {
+		return zeroPreimage, nil, fmt.Errorf("Wrong BestHeight: expected %v, "+
+			"got %v", c.expectedRequest.BestHeight, req.BestHeight)
+	}
 
-  return c.preimage, c.tempErr, c.permErr
+	return c.preimage, c.tempErr, c.permErr
 }
 
 func (c *mockExtpreimageClient) Stop() error {
-  return nil
+	return nil
 }
 
 type mockRegistry struct {
-  expectedHash     chainhash.Hash
-  expectedPreimage [32]byte
-  err              error
+	expectedHash     chainhash.Hash
+	expectedPreimage [32]byte
+	err              error
 }
 
 func (r *mockRegistry) AddInvoicePreimage(hash chainhash.Hash,
-  preimage [32]byte) error {
-  if r.err != nil {
-    return r.err
-  }
+	preimage [32]byte) error {
+	if r.err != nil {
+		return r.err
+	}
 
-  if !bytes.Equal(r.expectedHash[:], hash[:]) {
-    return fmt.Errorf("Wrong hash: expected %v, got %v",
-      r.expectedHash, hash)
-  }
+	if !bytes.Equal(r.expectedHash[:], hash[:]) {
+		return fmt.Errorf("Wrong hash: expected %v, got %v",
+			r.expectedHash, hash)
+	}
 
-  if !bytes.Equal(r.expectedPreimage[:], preimage[:]) {
-    return fmt.Errorf("Wrong preimage: expected %v, got %v",
-      r.expectedPreimage, preimage)
-  }
+	if !bytes.Equal(r.expectedPreimage[:], preimage[:]) {
+		return fmt.Errorf("Wrong preimage: expected %v, got %v",
+			r.expectedPreimage, preimage)
+	}
 
-  return nil
+	return nil
 }
 
 func TestGetPaymentHash(t *testing.T) {
-  var zeroPreimage [32]byte
-  var zeroHash [sha256.Size]byte
+	var zeroPreimage [32]byte
+	var zeroHash [sha256.Size]byte
 
-  var preimage [32]byte
-  _, err := rand.Read(preimage[:])
-  if err != nil {
-    t.Fatalf("Unable to create preimage: %v", err)
-  }
+	var preimage [32]byte
+	_, err := rand.Read(preimage[:])
+	if err != nil {
+		t.Fatalf("Unable to create preimage: %v", err)
+	}
 
-  hash := sha256.Sum256(preimage[:])
+	hash := sha256.Sum256(preimage[:])
 
-  tests := []struct {
-    name    string
-    invoice *channeldb.ContractTerm
-    hash    [sha256.Size]byte
-    err     error
-  }{
-    // if it is an external preimage, use the local hash
-    {
-      name: "external preimage with local hash",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: hash,
-      err:  nil,
-    },
-    // if it is an external preimage without a local hash, throw
-    {
-      name: "external preimage without local hash",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: zeroHash,
-      err: fmt.Errorf("Invoices with ExternalPreimage must " +
-        "have a locally defined PaymentHash."),
-    },
-    // if it is a local preimage without a preimage, throw
-    {
-      name: "local preimage without preimage",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: zeroHash,
-      err: fmt.Errorf("Invoices must have a preimage or" +
-        "use ExternalPreimages"),
-    },
-    // if it is a local preimage, calculate the hash
-    {
-      name: "local preimage with preimage",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: hash,
-      err:  nil,
-    },
-  }
+	tests := []struct {
+		name    string
+		invoice *channeldb.ContractTerm
+		hash    [sha256.Size]byte
+		err     error
+	}{
+		// if it is an external preimage, use the local hash
+		{
+			name: "external preimage with local hash",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: hash,
+			err:  nil,
+		},
+		// if it is an external preimage without a local hash, throw
+		{
+			name: "external preimage without local hash",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: zeroHash,
+			err: fmt.Errorf("Invoices with ExternalPreimage must " +
+				"have a locally defined PaymentHash."),
+		},
+		// if it is a local preimage without a preimage, throw
+		{
+			name: "local preimage without preimage",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: zeroHash,
+			err: fmt.Errorf("Invoices must have a preimage or" +
+				"use ExternalPreimages"),
+		},
+		// if it is a local preimage, calculate the hash
+		{
+			name: "local preimage with preimage",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: hash,
+			err:  nil,
+		},
+	}
 
-  for _, test := range tests {
-    hash, err := test.invoice.GetPaymentHash()
+	for _, test := range tests {
+		hash, err := test.invoice.GetPaymentHash()
 
-    if (err == nil && test.err != nil) ||
-      (err != nil && test.err == nil) ||
-      (err != nil && test.err != nil && err.Error() != test.err.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got err: %v, want err: %v",
-        test.name, err, test.err)
-    }
+		if (err == nil && test.err != nil) ||
+			(err != nil && test.err == nil) ||
+			(err != nil && test.err != nil && err.Error() != test.err.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got err: %v, want err: %v",
+				test.name, err, test.err)
+		}
 
-    if !bytes.Equal(hash[:], test.hash[:]) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got hash: %v, "+
-        "want hash: %v", test.name, hash, test.hash)
-    }
-  }
+		if !bytes.Equal(hash[:], test.hash[:]) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got hash: %v, "+
+				"want hash: %v", test.name, hash, test.hash)
+		}
+	}
 }
 
 func TestGetPaymentPreimage(t *testing.T) {
-  var zeroPreimage [32]byte
-  var zeroHash [sha256.Size]byte
+	var zeroPreimage [32]byte
+	var zeroHash [sha256.Size]byte
 
-  var preimage [32]byte
-  _, err := rand.Read(preimage[:])
-  if err != nil {
-    t.Fatalf("Unable to create preimage: %v", err)
-  }
+	var preimage [32]byte
+	_, err := rand.Read(preimage[:])
+	if err != nil {
+		t.Fatalf("Unable to create preimage: %v", err)
+	}
 
-  hash := sha256.Sum256(preimage[:])
+	hash := sha256.Sum256(preimage[:])
 
-  timeLock := uint32(288)
-  currentHeight := uint32(123456)
-  registry := &mockRegistry{}
+	timeLock := uint32(288)
+	currentHeight := uint32(123456)
+	registry := &mockRegistry{}
 
-  tests := []struct {
-    name              string
-    invoice           *channeldb.ContractTerm
-    timeLock          uint32
-    currentHeight     uint32
-    extpreimageClient extpreimage.Client
-    registry          channeldb.InvoiceRegistry
-    preimage          [32]byte
-    tempErr           error
-    permErr           error
-  }{
-    // if it has a preimage and is marked external, return it
-    {
-      name: "local preimage on external preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          preimage,
-      tempErr:           nil,
-      permErr:           nil,
-    },
-    // if it has a preimage and is not marked external, return it
-    {
-      name: "local preimage on local preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          preimage,
-      tempErr:           nil,
-      permErr:           nil,
-    },
-    // if it is not external preimage, and does not have a preimage, throw
-    {
-      name: "no preimage on local preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          zeroPreimage,
-      tempErr:           nil,
-      permErr:           fmt.Errorf("no preimage available on invoice"),
-    },
-    // if it is an external preimage, and there is no client, throw
-    {
-      name: "no extpreimage client",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: nil,
-      registry:          registry,
-      preimage:          zeroPreimage,
-      tempErr:           fmt.Errorf("no extpreimage client configured"),
-      permErr:           nil,
-    },
-    // if it is an external preimage, return it
-    {
-      name: "external preimage retrieved",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        expectedRequest: &extpreimage.PreimageRequest{
-          PaymentHash: hash,
-          // amounts are in satoshis, invoices are in millisatoshis
-          Amount:     1,
-          TimeLock:   timeLock,
-          BestHeight: currentHeight,
-        },
-        preimage: preimage,
-      },
-      registry: &mockRegistry{
-        expectedPreimage: preimage,
-        expectedHash:     hash,
-      },
-      preimage: preimage,
-      tempErr:  nil,
-      permErr:  nil,
-    },
-    // if it encounters a permanent error, return that
-    {
-      name: "external preimage permanent error",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: zeroPreimage,
-        permErr:  fmt.Errorf("fake permanent error"),
-      },
-      registry: registry,
-      preimage: zeroPreimage,
-      tempErr:  nil,
-      permErr:  fmt.Errorf("fake permanent error"),
-    },
-    // if it encounters a temporary error, return that
-    {
-      name: "external preimage temporary error",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: zeroPreimage,
-        tempErr:  fmt.Errorf("fake temporary error"),
-      },
-      registry: registry,
-      preimage: zeroPreimage,
-      tempErr:  fmt.Errorf("fake temporary error"),
-      permErr:  nil,
-    },
-    // if it is an external preimage and can't be added to the registry, throw
-    {
-      name: "AddInvoicePreimage failure",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: preimage,
-      },
-      registry: &mockRegistry{
-        err: fmt.Errorf("fake registry error"),
-      },
-      preimage: zeroPreimage,
-      tempErr:  fmt.Errorf("fake registry error"),
-      permErr:  nil,
-    },
-  }
+	tests := []struct {
+		name              string
+		invoice           *channeldb.ContractTerm
+		timeLock          uint32
+		currentHeight     uint32
+		extpreimageClient extpreimage.Client
+		registry          channeldb.InvoiceRegistry
+		preimage          [32]byte
+		tempErr           error
+		permErr           error
+	}{
+		// if it has a preimage and is marked external, return it
+		{
+			name: "local preimage on external preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          preimage,
+			tempErr:           nil,
+			permErr:           nil,
+		},
+		// if it has a preimage and is not marked external, return it
+		{
+			name: "local preimage on local preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          preimage,
+			tempErr:           nil,
+			permErr:           nil,
+		},
+		// if it is not external preimage, and does not have a preimage, throw
+		{
+			name: "no preimage on local preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          zeroPreimage,
+			tempErr:           nil,
+			permErr:           fmt.Errorf("no preimage available on invoice"),
+		},
+		// if it is an external preimage, and there is no client, throw
+		{
+			name: "no extpreimage client",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: nil,
+			registry:          registry,
+			preimage:          zeroPreimage,
+			tempErr:           fmt.Errorf("no extpreimage client configured"),
+			permErr:           nil,
+		},
+		// if it is an external preimage, return it
+		{
+			name: "external preimage retrieved",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				expectedRequest: &extpreimage.PreimageRequest{
+					PaymentHash: hash,
+					// amounts are in satoshis, invoices are in millisatoshis
+					Amount:     1,
+					TimeLock:   timeLock,
+					BestHeight: currentHeight,
+				},
+				preimage: preimage,
+			},
+			registry: &mockRegistry{
+				expectedPreimage: preimage,
+				expectedHash:     hash,
+			},
+			preimage: preimage,
+			tempErr:  nil,
+			permErr:  nil,
+		},
+		// if it encounters a permanent error, return that
+		{
+			name: "external preimage permanent error",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: zeroPreimage,
+				permErr:  fmt.Errorf("fake permanent error"),
+			},
+			registry: registry,
+			preimage: zeroPreimage,
+			tempErr:  nil,
+			permErr:  fmt.Errorf("fake permanent error"),
+		},
+		// if it encounters a temporary error, return that
+		{
+			name: "external preimage temporary error",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: zeroPreimage,
+				tempErr:  fmt.Errorf("fake temporary error"),
+			},
+			registry: registry,
+			preimage: zeroPreimage,
+			tempErr:  fmt.Errorf("fake temporary error"),
+			permErr:  nil,
+		},
+		// if it is an external preimage and can't be added to the registry, throw
+		{
+			name: "AddInvoicePreimage failure",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: preimage,
+			},
+			registry: &mockRegistry{
+				err: fmt.Errorf("fake registry error"),
+			},
+			preimage: zeroPreimage,
+			tempErr:  fmt.Errorf("fake registry error"),
+			permErr:  nil,
+		},
+	}
 
-  for _, test := range tests {
-    preimage, tempErr, permErr := test.invoice.GetPaymentPreimage(test.timeLock,
-      test.currentHeight, test.extpreimageClient, test.registry)
+	for _, test := range tests {
+		preimage, tempErr, permErr := test.invoice.GetPaymentPreimage(test.timeLock,
+			test.currentHeight, test.extpreimageClient, test.registry)
 
-    if (tempErr == nil && test.tempErr != nil) ||
-      (tempErr != nil && test.tempErr == nil) ||
-      (tempErr != nil && test.tempErr != nil &&
-        tempErr.Error() != test.tempErr.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got tempErr: %v, want tempErr: %v",
-        test.name, tempErr, test.tempErr)
-    }
+		if (tempErr == nil && test.tempErr != nil) ||
+			(tempErr != nil && test.tempErr == nil) ||
+			(tempErr != nil && test.tempErr != nil &&
+				tempErr.Error() != test.tempErr.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got tempErr: %v, want tempErr: %v",
+				test.name, tempErr, test.tempErr)
+		}
 
-    if (permErr == nil && test.permErr != nil) ||
-      (permErr != nil && test.permErr == nil) ||
-      (permErr != nil && test.permErr != nil &&
-        permErr.Error() != test.permErr.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got permErr: %v, want permErr: %v",
-        test.name, permErr, test.permErr)
-    }
+		if (permErr == nil && test.permErr != nil) ||
+			(permErr != nil && test.permErr == nil) ||
+			(permErr != nil && test.permErr != nil &&
+				permErr.Error() != test.permErr.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got permErr: %v, want permErr: %v",
+				test.name, permErr, test.permErr)
+		}
 
-    if !bytes.Equal(preimage[:], test.preimage[:]) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got preimage: %v, "+
-        "want preimage: %v", test.name, preimage, test.preimage)
-    }
-  }
+		if !bytes.Equal(preimage[:], test.preimage[:]) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got preimage: %v, "+
+				"want preimage: %v", test.name, preimage, test.preimage)
+		}
+	}
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -56,6 +56,9 @@ type WitnessBeacon interface {
 
 	// AddPreImage adds a newly discovered preimage to the global cache.
 	AddPreimage(pre []byte) error
+
+	// Stop shuts down the witness beacon.
+	Stop()
 }
 
 // ChannelArbitratorConfig contains all the functionality that the

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -57,8 +57,9 @@ type WitnessBeacon interface {
 	// AddPreImage adds a newly discovered preimage to the global cache.
 	AddPreimage(pre []byte) error
 
-	// Stop shuts down the witness beacon.
-	Stop()
+	// PollForPreimage polls for external preimages that we were not able to
+	// find yet.
+	PollForPreimage([]byte) bool
 }
 
 // ChannelArbitratorConfig contains all the functionality that the

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -58,7 +58,9 @@ func (m *mockPreimageCache) SubscribeUpdates() *contractcourt.WitnessSubscriptio
 	return nil
 }
 
-func (m *mockPreimageCache) Stop() {}
+func (m *mockPreimageCache) PollForPreimage(hash []byte) bool {
+	return false
+}
 
 type mockFeeEstimator struct {
 	byteFeeIn chan lnwallet.SatPerKWeight

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -58,6 +58,8 @@ func (m *mockPreimageCache) SubscribeUpdates() *contractcourt.WitnessSubscriptio
 	return nil
 }
 
+func (m *mockPreimageCache) Stop() {}
+
 type mockFeeEstimator struct {
 	byteFeeIn chan lnwallet.SatPerKWeight
 

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -518,7 +518,9 @@ func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
 	return nil
 }
 
-func (m *mockPreimageCache) Stop() {}
+func (m *mockPreimageCache) PollForPreimage(hash []byte) bool {
+	return false
+}
 
 // pubkeyFromHex parses a Bitcoin public key from a hex encoded string.
 func pubkeyFromHex(keyHex string) (*btcec.PublicKey, error) {

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -518,6 +518,8 @@ func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
 	return nil
 }
 
+func (m *mockPreimageCache) Stop() {}
+
 // pubkeyFromHex parses a Bitcoin public key from a hex encoded string.
 func pubkeyFromHex(keyHex string) (*btcec.PublicKey, error) {
 	bytes, err := hex.DecodeString(keyHex)

--- a/mock.go
+++ b/mock.go
@@ -321,3 +321,5 @@ func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
 
 	return nil
 }
+
+func (m *mockPreimageCache) Stop() {}

--- a/mock.go
+++ b/mock.go
@@ -322,4 +322,6 @@ func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
 	return nil
 }
 
-func (m *mockPreimageCache) Stop() {}
+func (m *mockPreimageCache) PollForPreimage(hash []byte) bool {
+	return false
+}

--- a/server.go
+++ b/server.go
@@ -1068,9 +1068,6 @@ func (s *server) Stop() error {
 	s.invoices.Stop()
 	s.fundingMgr.Stop()
 
-	// stop the witness beacon so we can stop polling for preimages.
-	s.witnessBeacon.Stop()
-
 	// If the extpreimage service was set up, we need to shutdown
 	// any outstanding connections to it.
 	if s.extpreimageClient != nil {

--- a/server.go
+++ b/server.go
@@ -1068,6 +1068,9 @@ func (s *server) Stop() error {
 	s.invoices.Stop()
 	s.fundingMgr.Stop()
 
+	// stop the witness beacon so we can stop polling for preimages.
+	s.witnessBeacon.Stop()
+
 	// If the extpreimage service was set up, we need to shutdown
 	// any outstanding connections to it.
 	if s.extpreimageClient != nil {

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sync"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -19,6 +20,13 @@ type preimageSubscriber struct {
 	quit chan struct{}
 }
 
+// witnessCache is an interface describing the subset of channeldb.WitnessCache
+// used by the witness beacon.
+type witnessCache interface {
+	LookupWitness(channeldb.WitnessType, []byte) ([]byte, error)
+	AddWitness(channeldb.WitnessType, []byte) error
+}
+
 // preimageBeacon is an implementation of the contractcourt.WitnessBeacon
 // interface, and the lnwallet.PreimageCache interface. This implementation is
 // concerned with a single witness type: sha256 hahsh preimages.
@@ -29,10 +37,25 @@ type preimageBeacon struct {
 
 	invoices htlcswitch.InvoiceDatabase
 
-	wCache *channeldb.WitnessCache
+	wCache witnessCache
 
 	clientCounter uint64
 	subscribers   map[uint64]*preimageSubscriber
+
+	pollCounter uint64
+	polls       map[uint64](chan bool)
+}
+
+// Stop shuts down the preimage beacon by quitting
+// all currently active polls.
+func (p *preimageBeacon) Stop() {
+	if p.polls == nil {
+		p.polls = make(map[uint64](chan bool))
+	}
+	for _, quit := range p.polls {
+		quit <- true
+	}
+	p.polls = make(map[uint64](chan bool))
 }
 
 // SubscribeUpdates returns a channel that will be sent upon *each* time a new
@@ -115,6 +138,10 @@ func (p *preimageBeacon) LookupPreimage(payHash []byte) ([]byte, bool) {
 		if tempErr != nil {
 			ltndLog.Errorf("temporary error while retrieving invoice "+
 				"preimage: %v", tempErr)
+			ltndLog.Debugf("initiating polling to retrieve preimage "+
+				"for payment hash: %v", payHash)
+
+			go p.pollExtpreimage(invoiceTerm, 10*time.Second)
 			return nil, false
 		}
 
@@ -131,6 +158,58 @@ func (p *preimageBeacon) LookupPreimage(payHash []byte) ([]byte, bool) {
 	}
 
 	return preimage, true
+}
+
+func (p *preimageBeacon) pollExtpreimage(i channeldb.InvoiceTerm,
+	pollInterval time.Duration) {
+	// create a channel for us to be able to stop polling if the
+	// preimage beacon is quit.
+	if p.polls == nil {
+		p.polls = make(map[uint64](chan bool))
+	}
+	pollID := p.pollCounter
+	quit := make(chan bool)
+	p.polls[pollID] = quit
+	p.pollCounter++
+	defer func() {
+		delete(p.polls, pollID)
+		close(quit)
+	}()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			preimage, tempErr, permErr := i.GetPaymentPreimage(uint32(0), uint32(0),
+				p.extpreimageClient, p.invoices)
+
+			// permanent errors indicate we no longer need to poll for this
+			// preimage, we'll never retrieve it.
+			if permErr != nil {
+				ltndLog.Errorf("permanent error while polling for invoice "+
+					"preimage: %v, stopping poll.", permErr)
+				return
+			}
+
+			// if we encountered another temporary error, just continue to poll.
+			if tempErr != nil {
+				ltndLog.Errorf("temporary error while polling for invoice "+
+					"preimage: %v, continuing poll.", tempErr)
+				continue
+			}
+
+			// if we encountered no permanent or temporary errors, we have our
+			// preimage and we can add it to the cache and stop polling.
+			ltndLog.Debugf("retrieved preimage=%x while polling.", preimage[:])
+			p.AddPreimage(preimage[:])
+			return
+		case <-quit:
+			ltndLog.Tracef("preimage Beacon shutting down, stopping poll.")
+			return
+		}
+	}
 }
 
 // AddPreImage adds a newly discovered preimage to the global cache, and also


### PR DESCRIPTION
This change adds polling for temporary errors in LookupPreimage.

Because LookupPreimage provides no feedback on success or failure, and because after LookupPreimage is called, callers subscribe to updates from `AddPreimage`, we need some mechanism to recover from temporary errors and get them to either a final errored (permanent error) or successful (recovered preimage) state.

Also, we need to account for the external preimage service being down as the source of the temporary error, meaning we cannot relying on grpc streaming to get feedback.

Instead, we add polling to LookupPreimage which is self-initiated if LookupPreimage encounters a temporary error while retrieving a preimage. This polling could result in the same preimage being recovered twice, but `AddWitness` (which `AddPreimage` calls) is idempotent, so this should cause no harm.

### To Do
- [x] unit tests
- [ ] ~~integration tests~~ *(witness beacon is stubbed in integration tests)*