### PR TITLE
add permissions for lookup payment status

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -326,6 +326,10 @@ var (
 			Entity: "offchain",
 			Action: "read",
 		}},
+		"/lnrpc.Lightning/LookupPaymentStatus": {{
+			Entity: "offchain",
+			Action: "read",
+		}},
 	}
 )
 


### PR DESCRIPTION
We merged the LookupPaymentStatus code, but when using it we had a permissions error:

```
error: Error while handling request: [ExternalPreimageService:getPreimage] {"timestamp":"2018-12-10T17:05:22.772Z"}
sparkswapd_1  | error: Error: 2 UNKNOWN: /lnrpc.Lightning/LookupPaymentStatus: unknown permissions required for method
```

It seems like the permissions for LookupPaymentStatus were not set, this PR adds them. 