### PR TITLE
channeldb+routing+switch: move payment tracking from rpcserver to router+switch

### DIFF
--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -39,6 +39,14 @@ var (
 	// created.
 	ErrNoPaymentsCreated = fmt.Errorf("there are no existing payments")
 
+	// ErrDuplicatePayment is returned when a payment with the target payment
+	// hash already exists.
+	ErrDuplicatePayment = fmt.Errorf("payment with payment hash already exists")
+
+	// ErrPaymentNotFound is returned when a payment with the target payment
+	// hash can't be found.
+	ErrPaymentNotFound = fmt.Errorf("unable to locate payment with that hash")
+
 	// ErrNodeNotFound is returned when node bucket exists, but node with
 	// specific identity can't be found.
 	ErrNodeNotFound = fmt.Errorf("link node with target identity not found")

--- a/channeldb/invoice_preimage_test.go
+++ b/channeldb/invoice_preimage_test.go
@@ -1,395 +1,395 @@
 package channeldb_test
 
 import (
-  "bytes"
-  "crypto/rand"
-  "crypto/sha256"
-  "fmt"
-  "testing"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
 
-  "github.com/btcsuite/btcd/chaincfg/chainhash"
-  "github.com/lightningnetwork/lnd/channeldb"
-  "github.com/lightningnetwork/lnd/extpreimage"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/extpreimage"
 )
 
 type mockExtpreimageClient struct {
-  extpreimage.Client
-  expectedRequest *extpreimage.PreimageRequest
-  preimage        [32]byte
-  tempErr         error
-  permErr         error
+	extpreimage.Client
+	expectedRequest *extpreimage.PreimageRequest
+	preimage        [32]byte
+	tempErr         error
+	permErr         error
 }
 
 func (c *mockExtpreimageClient) Retrieve(req *extpreimage.PreimageRequest) (
-  [32]byte, error, error) {
-  var zeroPreimage [32]byte
+	[32]byte, error, error) {
+	var zeroPreimage [32]byte
 
-  // if no expectation is set, just return whatever was passed
-  if c.expectedRequest == nil {
-    return c.preimage, c.tempErr, c.permErr
-  }
+	// if no expectation is set, just return whatever was passed
+	if c.expectedRequest == nil {
+		return c.preimage, c.tempErr, c.permErr
+	}
 
-  if !bytes.Equal(c.expectedRequest.PaymentHash[:], req.PaymentHash[:]) {
-    return zeroPreimage, nil, fmt.Errorf("Wrong PaymentHash: expected %v, "+
-      "got %v", c.expectedRequest.PaymentHash, req.PaymentHash)
-  }
+	if !bytes.Equal(c.expectedRequest.PaymentHash[:], req.PaymentHash[:]) {
+		return zeroPreimage, nil, fmt.Errorf("Wrong PaymentHash: expected %v, "+
+			"got %v", c.expectedRequest.PaymentHash, req.PaymentHash)
+	}
 
-  if c.expectedRequest.Amount != req.Amount {
-    return zeroPreimage, nil, fmt.Errorf("Wrong Amount: expected %v, "+
-      "got %v", c.expectedRequest.Amount, req.Amount)
-  }
+	if c.expectedRequest.Amount != req.Amount {
+		return zeroPreimage, nil, fmt.Errorf("Wrong Amount: expected %v, "+
+			"got %v", c.expectedRequest.Amount, req.Amount)
+	}
 
-  if c.expectedRequest.TimeLock != req.TimeLock {
-    return zeroPreimage, nil, fmt.Errorf("Wrong TimeLock: expected %v, "+
-      "got %v", c.expectedRequest.TimeLock, req.TimeLock)
-  }
+	if c.expectedRequest.TimeLock != req.TimeLock {
+		return zeroPreimage, nil, fmt.Errorf("Wrong TimeLock: expected %v, "+
+			"got %v", c.expectedRequest.TimeLock, req.TimeLock)
+	}
 
-  if c.expectedRequest.BestHeight != req.BestHeight {
-    return zeroPreimage, nil, fmt.Errorf("Wrong BestHeight: expected %v, "+
-      "got %v", c.expectedRequest.BestHeight, req.BestHeight)
-  }
+	if c.expectedRequest.BestHeight != req.BestHeight {
+		return zeroPreimage, nil, fmt.Errorf("Wrong BestHeight: expected %v, "+
+			"got %v", c.expectedRequest.BestHeight, req.BestHeight)
+	}
 
-  return c.preimage, c.tempErr, c.permErr
+	return c.preimage, c.tempErr, c.permErr
 }
 
 func (c *mockExtpreimageClient) Stop() error {
-  return nil
+	return nil
 }
 
 type mockRegistry struct {
-  expectedHash     chainhash.Hash
-  expectedPreimage [32]byte
-  err              error
+	expectedHash     chainhash.Hash
+	expectedPreimage [32]byte
+	err              error
 }
 
 func (r *mockRegistry) AddInvoicePreimage(hash chainhash.Hash,
-  preimage [32]byte) error {
-  if r.err != nil {
-    return r.err
-  }
+	preimage [32]byte) error {
+	if r.err != nil {
+		return r.err
+	}
 
-  if !bytes.Equal(r.expectedHash[:], hash[:]) {
-    return fmt.Errorf("Wrong hash: expected %v, got %v",
-      r.expectedHash, hash)
-  }
+	if !bytes.Equal(r.expectedHash[:], hash[:]) {
+		return fmt.Errorf("Wrong hash: expected %v, got %v",
+			r.expectedHash, hash)
+	}
 
-  if !bytes.Equal(r.expectedPreimage[:], preimage[:]) {
-    return fmt.Errorf("Wrong preimage: expected %v, got %v",
-      r.expectedPreimage, preimage)
-  }
+	if !bytes.Equal(r.expectedPreimage[:], preimage[:]) {
+		return fmt.Errorf("Wrong preimage: expected %v, got %v",
+			r.expectedPreimage, preimage)
+	}
 
-  return nil
+	return nil
 }
 
 func TestGetPaymentHash(t *testing.T) {
-  var zeroPreimage [32]byte
-  var zeroHash [sha256.Size]byte
+	var zeroPreimage [32]byte
+	var zeroHash [sha256.Size]byte
 
-  var preimage [32]byte
-  _, err := rand.Read(preimage[:])
-  if err != nil {
-    t.Fatalf("Unable to create preimage: %v", err)
-  }
+	var preimage [32]byte
+	_, err := rand.Read(preimage[:])
+	if err != nil {
+		t.Fatalf("Unable to create preimage: %v", err)
+	}
 
-  hash := sha256.Sum256(preimage[:])
+	hash := sha256.Sum256(preimage[:])
 
-  tests := []struct {
-    name    string
-    invoice *channeldb.ContractTerm
-    hash    [sha256.Size]byte
-    err     error
-  }{
-    // if it is an external preimage, use the local hash
-    {
-      name: "external preimage with local hash",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: hash,
-      err:  nil,
-    },
-    // if it is an external preimage without a local hash, throw
-    {
-      name: "external preimage without local hash",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: zeroHash,
-      err: fmt.Errorf("Invoices with ExternalPreimage must " +
-        "have a locally defined PaymentHash."),
-    },
-    // if it is a local preimage without a preimage, throw
-    {
-      name: "local preimage without preimage",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: zeroHash,
-      err: fmt.Errorf("Invoices must have a preimage or" +
-        "use ExternalPreimages"),
-    },
-    // if it is a local preimage, calculate the hash
-    {
-      name: "local preimage with preimage",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      hash: hash,
-      err:  nil,
-    },
-  }
+	tests := []struct {
+		name    string
+		invoice *channeldb.ContractTerm
+		hash    [sha256.Size]byte
+		err     error
+	}{
+		// if it is an external preimage, use the local hash
+		{
+			name: "external preimage with local hash",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: hash,
+			err:  nil,
+		},
+		// if it is an external preimage without a local hash, throw
+		{
+			name: "external preimage without local hash",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: zeroHash,
+			err: fmt.Errorf("Invoices with ExternalPreimage must " +
+				"have a locally defined PaymentHash."),
+		},
+		// if it is a local preimage without a preimage, throw
+		{
+			name: "local preimage without preimage",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: zeroHash,
+			err: fmt.Errorf("Invoices must have a preimage or" +
+				"use ExternalPreimages"),
+		},
+		// if it is a local preimage, calculate the hash
+		{
+			name: "local preimage with preimage",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			hash: hash,
+			err:  nil,
+		},
+	}
 
-  for _, test := range tests {
-    hash, err := test.invoice.GetPaymentHash()
+	for _, test := range tests {
+		hash, err := test.invoice.GetPaymentHash()
 
-    if (err == nil && test.err != nil) ||
-      (err != nil && test.err == nil) ||
-      (err != nil && test.err != nil && err.Error() != test.err.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got err: %v, want err: %v",
-        test.name, err, test.err)
-    }
+		if (err == nil && test.err != nil) ||
+			(err != nil && test.err == nil) ||
+			(err != nil && test.err != nil && err.Error() != test.err.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got err: %v, want err: %v",
+				test.name, err, test.err)
+		}
 
-    if !bytes.Equal(hash[:], test.hash[:]) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got hash: %v, "+
-        "want hash: %v", test.name, hash, test.hash)
-    }
-  }
+		if !bytes.Equal(hash[:], test.hash[:]) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got hash: %v, "+
+				"want hash: %v", test.name, hash, test.hash)
+		}
+	}
 }
 
 func TestGetPaymentPreimage(t *testing.T) {
-  var zeroPreimage [32]byte
-  var zeroHash [sha256.Size]byte
+	var zeroPreimage [32]byte
+	var zeroHash [sha256.Size]byte
 
-  var preimage [32]byte
-  _, err := rand.Read(preimage[:])
-  if err != nil {
-    t.Fatalf("Unable to create preimage: %v", err)
-  }
+	var preimage [32]byte
+	_, err := rand.Read(preimage[:])
+	if err != nil {
+		t.Fatalf("Unable to create preimage: %v", err)
+	}
 
-  hash := sha256.Sum256(preimage[:])
+	hash := sha256.Sum256(preimage[:])
 
-  timeLock := uint32(288)
-  currentHeight := uint32(123456)
-  registry := &mockRegistry{}
+	timeLock := uint32(288)
+	currentHeight := uint32(123456)
+	registry := &mockRegistry{}
 
-  tests := []struct {
-    name              string
-    invoice           *channeldb.ContractTerm
-    timeLock          uint32
-    currentHeight     uint32
-    extpreimageClient extpreimage.Client
-    registry          channeldb.InvoiceRegistry
-    preimage          [32]byte
-    tempErr           error
-    permErr           error
-  }{
-    // if it has a preimage and is marked external, return it
-    {
-      name: "local preimage on external preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          preimage,
-      tempErr:           nil,
-      permErr:           nil,
-    },
-    // if it has a preimage and is not marked external, return it
-    {
-      name: "local preimage on local preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  preimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          preimage,
-      tempErr:           nil,
-      permErr:           nil,
-    },
-    // if it is not external preimage, and does not have a preimage, throw
-    {
-      name: "no preimage on local preimage invoice",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: false,
-        PaymentHash:      zeroHash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: &mockExtpreimageClient{},
-      registry:          registry,
-      preimage:          zeroPreimage,
-      tempErr:           nil,
-      permErr:           fmt.Errorf("no preimage available on invoice"),
-    },
-    // if it is an external preimage, and there is no client, throw
-    {
-      name: "no extpreimage client",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:          timeLock,
-      currentHeight:     currentHeight,
-      extpreimageClient: nil,
-      registry:          registry,
-      preimage:          zeroPreimage,
-      tempErr:           fmt.Errorf("no extpreimage client configured"),
-      permErr:           nil,
-    },
-    // if it is an external preimage, return it
-    {
-      name: "external preimage retrieved",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        expectedRequest: &extpreimage.PreimageRequest{
-          PaymentHash: hash,
-          // amounts are in satoshis, invoices are in millisatoshis
-          Amount:     1,
-          TimeLock:   timeLock,
-          BestHeight: currentHeight,
-        },
-        preimage: preimage,
-      },
-      registry: &mockRegistry{
-        expectedPreimage: preimage,
-        expectedHash:     hash,
-      },
-      preimage: preimage,
-      tempErr:  nil,
-      permErr:  nil,
-    },
-    // if it encounters a permanent error, return that
-    {
-      name: "external preimage permanent error",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: zeroPreimage,
-        permErr:  fmt.Errorf("fake permanent error"),
-      },
-      registry: registry,
-      preimage: zeroPreimage,
-      tempErr:  nil,
-      permErr:  fmt.Errorf("fake permanent error"),
-    },
-    // if it encounters a temporary error, return that
-    {
-      name: "external preimage temporary error",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: zeroPreimage,
-        tempErr:  fmt.Errorf("fake temporary error"),
-      },
-      registry: registry,
-      preimage: zeroPreimage,
-      tempErr:  fmt.Errorf("fake temporary error"),
-      permErr:  nil,
-    },
-    // if it is an external preimage and can't be added to the registry, throw
-    {
-      name: "AddInvoicePreimage failure",
-      invoice: &channeldb.ContractTerm{
-        ExternalPreimage: true,
-        PaymentHash:      hash,
-        PaymentPreimage:  zeroPreimage,
-        Value:            1000,
-        Settled:          false,
-      },
-      timeLock:      timeLock,
-      currentHeight: currentHeight,
-      extpreimageClient: &mockExtpreimageClient{
-        preimage: preimage,
-      },
-      registry: &mockRegistry{
-        err: fmt.Errorf("fake registry error"),
-      },
-      preimage: zeroPreimage,
-      tempErr:  fmt.Errorf("fake registry error"),
-      permErr:  nil,
-    },
-  }
+	tests := []struct {
+		name              string
+		invoice           *channeldb.ContractTerm
+		timeLock          uint32
+		currentHeight     uint32
+		extpreimageClient extpreimage.Client
+		registry          channeldb.InvoiceRegistry
+		preimage          [32]byte
+		tempErr           error
+		permErr           error
+	}{
+		// if it has a preimage and is marked external, return it
+		{
+			name: "local preimage on external preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          preimage,
+			tempErr:           nil,
+			permErr:           nil,
+		},
+		// if it has a preimage and is not marked external, return it
+		{
+			name: "local preimage on local preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  preimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          preimage,
+			tempErr:           nil,
+			permErr:           nil,
+		},
+		// if it is not external preimage, and does not have a preimage, throw
+		{
+			name: "no preimage on local preimage invoice",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: false,
+				PaymentHash:      zeroHash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: &mockExtpreimageClient{},
+			registry:          registry,
+			preimage:          zeroPreimage,
+			tempErr:           nil,
+			permErr:           fmt.Errorf("no preimage available on invoice"),
+		},
+		// if it is an external preimage, and there is no client, throw
+		{
+			name: "no extpreimage client",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:          timeLock,
+			currentHeight:     currentHeight,
+			extpreimageClient: nil,
+			registry:          registry,
+			preimage:          zeroPreimage,
+			tempErr:           fmt.Errorf("no extpreimage client configured"),
+			permErr:           nil,
+		},
+		// if it is an external preimage, return it
+		{
+			name: "external preimage retrieved",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				expectedRequest: &extpreimage.PreimageRequest{
+					PaymentHash: hash,
+					// amounts are in satoshis, invoices are in millisatoshis
+					Amount:     1,
+					TimeLock:   timeLock,
+					BestHeight: currentHeight,
+				},
+				preimage: preimage,
+			},
+			registry: &mockRegistry{
+				expectedPreimage: preimage,
+				expectedHash:     hash,
+			},
+			preimage: preimage,
+			tempErr:  nil,
+			permErr:  nil,
+		},
+		// if it encounters a permanent error, return that
+		{
+			name: "external preimage permanent error",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: zeroPreimage,
+				permErr:  fmt.Errorf("fake permanent error"),
+			},
+			registry: registry,
+			preimage: zeroPreimage,
+			tempErr:  nil,
+			permErr:  fmt.Errorf("fake permanent error"),
+		},
+		// if it encounters a temporary error, return that
+		{
+			name: "external preimage temporary error",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: zeroPreimage,
+				tempErr:  fmt.Errorf("fake temporary error"),
+			},
+			registry: registry,
+			preimage: zeroPreimage,
+			tempErr:  fmt.Errorf("fake temporary error"),
+			permErr:  nil,
+		},
+		// if it is an external preimage and can't be added to the registry, throw
+		{
+			name: "AddInvoicePreimage failure",
+			invoice: &channeldb.ContractTerm{
+				ExternalPreimage: true,
+				PaymentHash:      hash,
+				PaymentPreimage:  zeroPreimage,
+				Value:            1000,
+				Settled:          false,
+			},
+			timeLock:      timeLock,
+			currentHeight: currentHeight,
+			extpreimageClient: &mockExtpreimageClient{
+				preimage: preimage,
+			},
+			registry: &mockRegistry{
+				err: fmt.Errorf("fake registry error"),
+			},
+			preimage: zeroPreimage,
+			tempErr:  fmt.Errorf("fake registry error"),
+			permErr:  nil,
+		},
+	}
 
-  for _, test := range tests {
-    preimage, tempErr, permErr := test.invoice.GetPaymentPreimage(test.timeLock,
-      test.currentHeight, test.extpreimageClient, test.registry)
+	for _, test := range tests {
+		preimage, tempErr, permErr := test.invoice.GetPaymentPreimage(test.timeLock,
+			test.currentHeight, test.extpreimageClient, test.registry)
 
-    if (tempErr == nil && test.tempErr != nil) ||
-      (tempErr != nil && test.tempErr == nil) ||
-      (tempErr != nil && test.tempErr != nil &&
-        tempErr.Error() != test.tempErr.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got tempErr: %v, want tempErr: %v",
-        test.name, tempErr, test.tempErr)
-    }
+		if (tempErr == nil && test.tempErr != nil) ||
+			(tempErr != nil && test.tempErr == nil) ||
+			(tempErr != nil && test.tempErr != nil &&
+				tempErr.Error() != test.tempErr.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got tempErr: %v, want tempErr: %v",
+				test.name, tempErr, test.tempErr)
+		}
 
-    if (permErr == nil && test.permErr != nil) ||
-      (permErr != nil && test.permErr == nil) ||
-      (permErr != nil && test.permErr != nil &&
-        permErr.Error() != test.permErr.Error()) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got permErr: %v, want permErr: %v",
-        test.name, permErr, test.permErr)
-    }
+		if (permErr == nil && test.permErr != nil) ||
+			(permErr != nil && test.permErr == nil) ||
+			(permErr != nil && test.permErr != nil &&
+				permErr.Error() != test.permErr.Error()) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got permErr: %v, want permErr: %v",
+				test.name, permErr, test.permErr)
+		}
 
-    if !bytes.Equal(preimage[:], test.preimage[:]) {
-      t.Errorf("GetPaymentHash test \"%s\" failed, got preimage: %v, "+
-        "want preimage: %v", test.name, preimage, test.preimage)
-    }
-  }
+		if !bytes.Equal(preimage[:], test.preimage[:]) {
+			t.Errorf("GetPaymentHash test \"%s\" failed, got preimage: %v, "+
+				"want preimage: %v", test.name, preimage, test.preimage)
+		}
+	}
 }

--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -442,6 +442,13 @@ func paymentStatusesMigration(tx *bolt.Tx) error {
 			return err
 		}
 
+		var zeroPreimage [32]byte
+		if bytes.Equal(payment.PaymentPreimage[:], zeroPreimage[:]) {
+			// ignore payments without preimages, as these are
+			// not considered complete
+			return nil
+		}
+
 		// Calculate payment hash for current payment.
 		paymentHash := sha256.Sum256(payment.PaymentPreimage[:])
 

--- a/channeldb/migrations_test.go
+++ b/channeldb/migrations_test.go
@@ -19,14 +19,20 @@ import (
 func TestPaymentStatusesMigration(t *testing.T) {
 	t.Parallel()
 
-	fakePayment := makeFakePayment()
+	fakePayment := makeCompleteFakePayment()
 	paymentHash := sha256.Sum256(fakePayment.PaymentPreimage[:])
 
 	// Add fake payment to test database, verifying that it was created,
 	// that we have only one payment, and its status is not "Completed".
 	beforeMigrationFunc := func(d *DB) {
-		if err := d.AddPayment(fakePayment); err != nil {
+		err := d.AddPayment(paymentHash, fakePayment.Invoice.Terms.Value)
+		if err != nil {
 			t.Fatalf("unable to add payment: %v", err)
+		}
+
+		err = d.UpdatePaymentPreimage(fakePayment.PaymentPreimage)
+		if err != nil {
+			t.Fatalf("unable to update payment preimage")
 		}
 
 		payments, err := d.FetchAllPayments()

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -30,6 +30,9 @@ var (
 	// paymentStatusBucket is the name of the bucket within the database that
 	// stores the status of a payment indexed by the payment's preimage.
 	paymentStatusBucket = []byte("payment-status")
+
+	// now is a replacement for time.Now to allow us to stub it for testing
+	now = time.Now
 )
 
 // PaymentStatus represent current status of payment
@@ -127,7 +130,7 @@ func (db *DB) AddPayment(paymentHash [32]byte,
 			Terms: ContractTerm{
 				Value: amount,
 			},
-			CreationDate: time.Now(),
+			CreationDate: now(),
 		},
 	}
 

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -156,6 +156,8 @@ func (db *DB) AddPayment(paymentHash [32]byte,
 			return err
 		}
 
+		// Create the bucket for mapping payment hashes to IDs so that we can
+		// retrieve and update payments later.
 		paymentHashIndex, err := tx.CreateBucketIfNotExists(paymentHashIndexBucket)
 		if err != nil {
 			return err
@@ -226,6 +228,11 @@ func (db *DB) UpdatePaymentPreimage(paymentPreimage [32]byte) error {
 	return db.updatePayment(paymentHash, updatePreimage)
 }
 
+// paymentUpdater is a function passed into updatePayment
+// that modifies a provided OutgoingPayment and returns it.
+// This use of a function to do modification allows us
+// to consolidate the retrieval and saving portions of
+// updating a payment.
 type paymentUpdater func(*OutgoingPayment) *OutgoingPayment
 
 // updatePayment retrieves an existing payment in the database

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -119,9 +119,10 @@ type OutgoingPayment struct {
 }
 
 // AddPayment saves an payment to the database and indexes it by payment
-// hash for later retrieval and update. It only includes part of the info
-// that a complete payment has as until it is complete, the route
-// and preimage are unknown.
+// hash for later retrieval and update. Initially it contains only the amount
+// of the payment and its creation date. It's route and preimage are added
+// later in the payment lifecycle in UpdatePaymentRoute and
+// UpdatePaymentPreimage, respecitively.
 func (db *DB) AddPayment(paymentHash [32]byte,
 	amount lnwire.MilliSatoshi) error {
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -3935,6 +3935,12 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 		t.Fatalf("unable to add invoice in carol registry: %v", err)
 	}
 
+	err = n.aliceServer.htlcSwitch.cfg.DB.AddPayment(
+		htlc.PaymentHash, htlc.Amount)
+	if err != nil {
+		t.Fatalf("unable to add payment to alice payments db: %v", err)
+	}
+
 	// With the invoice now added to Carol's registry, we'll send the
 	// payment. It should succeed w/o any issues as it has been crafted
 	// properly.

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -890,6 +890,16 @@ func (s *Switch) handleLocalResponse(pkt *htlcPacket) {
 
 		preimage = htlc.PaymentPreimage
 
+		// Update this payment's record with the preimage now that
+		// we have it. This will allow us to retrieve the preimage
+		// if the payment is attempted in the future.
+		err = s.cfg.DB.UpdatePaymentPreimage(preimage)
+		if err != nil {
+			log.Warnf("Unable to persist payment preimage %x: %v",
+				pkt.circuit.PaymentHash, err)
+			return
+		}
+
 	// We've received a fail update which means we can finalize the user
 	// payment and return fail response.
 	case *lnwire.UpdateFailHTLC:

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -733,6 +733,16 @@ func (n *threeHopNetwork) makePayment(sendingPeer, receivingPeer lnpeer.Peer,
 		}
 	}
 
+	// add the payment to the sender so that it can update the payment
+	// through its progress
+	if err := sender.htlcSwitch.cfg.DB.AddPayment(rhash, htlcAmt); err != nil {
+		paymentErr <- err
+		return &paymentResponse{
+			rhash: rhash,
+			err:   paymentErr,
+		}
+	}
+
 	// Send payment and expose err channel.
 	go func() {
 		_, err := sender.htlcSwitch.SendHTLC(
@@ -785,6 +795,16 @@ func (n *threeHopNetwork) makeExtpreimagePayment(sendingPeer,
 
 	// Check who is last in the route and add invoice to server registry.
 	if err := receiver.registry.AddInvoice(*invoice); err != nil {
+		paymentErr <- err
+		return &paymentResponse{
+			rhash: rhash,
+			err:   paymentErr,
+		}
+	}
+
+	// add the payment to the sender so that it can update the payment
+	// through its progress
+	if err := sender.htlcSwitch.cfg.DB.AddPayment(rhash, htlcAmt); err != nil {
 		paymentErr <- err
 		return &paymentResponse{
 			rhash: rhash,

--- a/routing/router.go
+++ b/routing/router.go
@@ -146,6 +146,10 @@ type ChannelPolicy struct {
 // the configuration MUST be non-nil for the ChannelRouter to carry out its
 // duties.
 type Config struct {
+	// DB is the database that the ChannelRouter will use to store
+	// payments when they are initiated.
+	DB *channeldb.DB
+
 	// Graph is the channel graph that the ChannelRouter will use to gather
 	// metrics from and also to carry out path finding queries.
 	// TODO(roasbeef): make into an interface
@@ -1654,6 +1658,13 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 		return [32]byte{}, nil, err
 	}
 
+	// We save the payment in the database before attempting any payments
+	// so that we will have a record of its' existence despite the outcome.
+	err := r.savePayment(payment)
+	if err != nil {
+		return preImage, nil, err
+	}
+
 	var finalCLTVDelta uint16
 	if payment.FinalCLTVDelta == nil {
 		finalCLTVDelta = DefaultFinalCLTVDelta
@@ -1714,6 +1725,13 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 				return spew.Sdump(route)
 			}),
 		)
+
+		// Update the payment's route so that if it succeeds
+		// we know what path it took and what the fees were.
+		err := r.addPaymentRoute(payment, route)
+		if err != nil {
+			return preImage, nil, err
+		}
 
 		// Generate the raw encoded sphinx packet to be included along
 		// with the htlcAdd message that we send directly to the
@@ -1989,6 +2007,32 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 
 		return preImage, route, nil
 	}
+}
+
+// savePayment saves a payment before any attempts have taken place
+// in the router.
+func (r *ChannelRouter) savePayment(payment *LightningPayment) error {
+	return r.cfg.DB.AddPayment(payment.paymentHash, payment.Amount)
+}
+
+// addPaymentRoute updates an existing payment with a particular route
+// for a given routing attempt.
+func (r *ChannelRouter) addPaymentRoute(payment *LightningPayment,
+	route *Route) error {
+
+	paymentPath := make([][33]byte, len(route.Hops))
+	for i, hop := range route.Hops {
+		hopPub := hop.PubKeyBytes
+		copy(paymentPath[i][:], hopPub[:])
+	}
+
+	r := &channeldb.OutgoingPaymentRoute{
+		Path:           paymentPath,
+		Fee:            route.TotalFees,
+		TimeLockLength: route.TotalTimeLock,
+	}
+
+	return r.cfg.DB.UpdatePaymentRoute(payment.PaymentHash, r)
 }
 
 // pruneVertexFailure will attempt to prune a vertex from the current available

--- a/routing/router.go
+++ b/routing/router.go
@@ -1660,7 +1660,7 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 
 	// We save the payment in the database before attempting any payments
 	// so that we will have a record of its' existence despite the outcome.
-	err := r.savePayment(payment)
+	err = r.savePayment(payment)
 	if err != nil {
 		return preImage, nil, err
 	}
@@ -1728,7 +1728,7 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 
 		// Update the payment's route so that if it succeeds
 		// we know what path it took and what the fees were.
-		err := r.addPaymentRoute(payment, route)
+		err = r.addPaymentRoute(payment, route)
 		if err != nil {
 			return preImage, nil, err
 		}
@@ -2012,7 +2012,7 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 // savePayment saves a payment before any attempts have taken place
 // in the router.
 func (r *ChannelRouter) savePayment(payment *LightningPayment) error {
-	return r.cfg.DB.AddPayment(payment.paymentHash, payment.Amount)
+	return r.cfg.DB.AddPayment(payment.PaymentHash, payment.Amount)
 }
 
 // addPaymentRoute updates an existing payment with a particular route
@@ -2026,13 +2026,13 @@ func (r *ChannelRouter) addPaymentRoute(payment *LightningPayment,
 		copy(paymentPath[i][:], hopPub[:])
 	}
 
-	r := &channeldb.OutgoingPaymentRoute{
+	outgoingRoute := &channeldb.OutgoingPaymentRoute{
 		Path:           paymentPath,
 		Fee:            route.TotalFees,
 		TimeLockLength: route.TotalTimeLock,
 	}
 
-	return r.cfg.DB.UpdatePaymentRoute(payment.PaymentHash, r)
+	return r.cfg.DB.UpdatePaymentRoute(payment.PaymentHash, outgoingRoute)
 }
 
 // pruneVertexFailure will attempt to prune a vertex from the current available

--- a/routing/router.go
+++ b/routing/router.go
@@ -142,13 +142,21 @@ type ChannelPolicy struct {
 	TimeLockDelta uint32
 }
 
+// paymentDB is the interface implemented by channeldb for storing
+// payments when they are initated in the router.
+type paymentDB interface {
+	AddPayment(paymentHash [32]byte, amount lnwire.MilliSatoshi) error
+	UpdatePaymentRoute(paymentHash [32]byte,
+		route *channeldb.OutgoingPaymentRoute) error
+}
+
 // Config defines the configuration for the ChannelRouter. ALL elements within
 // the configuration MUST be non-nil for the ChannelRouter to carry out its
 // duties.
 type Config struct {
 	// DB is the database that the ChannelRouter will use to store
 	// payments when they are initiated.
-	DB *channeldb.DB
+	DB paymentDB
 
 	// Graph is the channel graph that the ChannelRouter will use to gather
 	// metrics from and also to carry out path finding queries.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2300,15 +2300,6 @@ func (r *rpcServer) dispatchPaymentIntent(
 		}, nil
 	}
 
-	// If a route was used to complete this payment, then we'll need to
-	// compute the final amount sent
-	var amt lnwire.MilliSatoshi
-	if len(payIntent.routes) > 0 {
-		amt = route.TotalAmount - route.TotalFees
-	} else {
-		amt = payIntent.msat
-	}
-
 	return &paymentIntentResponse{
 		Route:    route,
 		Preimage: preImage,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1950,33 +1950,6 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 	return resp, nil
 }
 
-// savePayment saves a successfully completed payment to the database for
-// historical record keeping.
-func (r *rpcServer) savePayment(route *routing.Route,
-	amount lnwire.MilliSatoshi, preImage []byte) error {
-
-	paymentPath := make([][33]byte, len(route.Hops))
-	for i, hop := range route.Hops {
-		hopPub := hop.PubKeyBytes
-		copy(paymentPath[i][:], hopPub[:])
-	}
-
-	payment := &channeldb.OutgoingPayment{
-		Invoice: channeldb.Invoice{
-			Terms: channeldb.ContractTerm{
-				Value: amount,
-			},
-			CreationDate: time.Now(),
-		},
-		Path:           paymentPath,
-		Fee:            route.TotalFees,
-		TimeLockLength: route.TotalTimeLock,
-	}
-	copy(payment.PaymentPreimage[:], preImage)
-
-	return r.server.chanDB.AddPayment(payment)
-}
-
 // validatePayReqExpiry checks if the passed payment request has expired. In
 // the case it has expired, an error will be returned.
 func validatePayReqExpiry(payReq *zpay32.Invoice) error {
@@ -2334,15 +2307,6 @@ func (r *rpcServer) dispatchPaymentIntent(
 		amt = route.TotalAmount - route.TotalFees
 	} else {
 		amt = payIntent.msat
-	}
-
-	// Save the completed payment to the database for record keeping
-	// purposes.
-	err := r.savePayment(route, amt, preImage[:])
-	if err != nil {
-		// We weren't able to save the payment, so we return the save
-		// err, but a nil routing err.
-		return nil, err
 	}
 
 	return &paymentIntentResponse{

--- a/server.go
+++ b/server.go
@@ -528,6 +528,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	s.currentNodeAnn = nodeAnn
 
 	s.chanRouter, err = routing.New(routing.Config{
+		DB:        chanDB,
 		Graph:     chanGraph,
 		Chain:     cc.chainIO,
 		ChainView: cc.chainView,


### PR DESCRIPTION
This change removes responsibility for creating payments in the database
from the rpcserver and the original sender of the payment to the router
and the switch.

Previously, anytime the original sender was no longer available (e.g.
because lnd restarted or the client closed the stream) the payment would
not be saved in the database, and the preimage would not be available.

Now, the payment is originally created in the router before any payment
attempts are created, but is saved without a preimage. When a payment is
attempted, the payment in the database is updated with the route being attempted.
When the payment is finally complete and a preimage is available, the payment
is updated in the database with the preimage by the switch, which is guaranteed
to be alive when the payment completes.

Making this change required creating a new index for the payments by their
hash so that they can be retrieved and updated without knowing the order
in which they were inserted.

Specific changes include:
- Add an index for payments by payment hash
- Require a payment hash when adding a payment
- Add UpdatePaymentRoute function to the DB
- Add UpdatePaymentPreimage function to the DB
- Create payments in the Router, add Preimages in the Switch