### PR TITLE
Update LTCD to latest master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -190,12 +190,12 @@
   revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
 
 [[projects]]
-  digest = "1:bc38c7c481812e178d85160472e231c5e1c9a7f5845d67e23ee4e706933c10d8"
+  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
   name = "github.com/golang/mock"
   packages = ["gomock"]
   pruneopts = "UT"
-  revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
-  version = "v1.1.1"
+  revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:52f82517e64acdc35d16c476fb8bd9191aa205eb36a450a3fc0dd5b3fe27a4ab"
@@ -298,7 +298,8 @@
   revision = "ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940"
 
 [[projects]]
-  digest = "1:81e36f059f2dfe7a5c07d55cabf8a7f0183f22d75bb6daa9b2935855bdd7c6af"
+  branch = "master"
+  digest = "1:499808df2d0ec0229f9dae95871a0893346228280a6beb26dd0b1d5c4650471b"
   name = "github.com/ltcsuite/ltcd"
   packages = [
     "chaincfg",
@@ -306,7 +307,7 @@
     "wire",
   ]
   pruneopts = "UT"
-  revision = "01737289d815e0e32c91e55593ba2fbd8d090b2c"
+  revision = "f37f8bf35796325487af28e0e01c2528dd97ea95"
 
 [[projects]]
   digest = "1:a0bf6f18ffeb4a45fd00d5eb16d918769bbe0e2dc7824e95abf05a3306f60102"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,7 +298,6 @@
   revision = "ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940"
 
 [[projects]]
-  branch = "master"
   digest = "1:499808df2d0ec0229f9dae95871a0893346228280a6beb26dd0b1d5c4650471b"
   name = "github.com/ltcsuite/ltcd"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,10 +51,6 @@
   revision = "ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940"
 
 [[constraint]]
-  name = "github.com/ltcsuite/ltcd"
-  revision = "01737289d815e0e32c91e55593ba2fbd8d090b2c"
-
-[[constraint]]
   name = "github.com/miekg/dns"
   revision = "79bfde677fa81ff8d27c4330c35bda075d360641"
 
@@ -125,3 +121,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/ltcsuite/ltcd"
+  revision = "f37f8bf35796325487af28e0e01c2528dd97ea95"


### PR DESCRIPTION
This PR fixes an issue where we have LTCD pegged on commit `01737289d815e0e32c91e55593ba2fbd8d090b2c` which does not exist in the ltcd revision tree. 

LTCD went through an upgrade to bring the codebase up to BTCD, where the LTCD repo was reforked, modifying the history of the project and removing a few changes that are now present in the latest code (only under different commits)

LTCD is now at latest master commit