### PR TITLE
changed port for regtest

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -89,7 +89,7 @@ var litecoinSimNetParams = litecoinNetParams{
 // regtest on ltc, however litecoind/ltcd has param information for this setup
 var litecoinRegTestNetParams = litecoinNetParams{
 	Params:   &litecoinCfg.RegressionNetParams,
-	rpcPort:  "19334",
+	rpcPort:  "18334",
 	CoinType: keychain.CoinTypeTestnet,
 }
 


### PR DESCRIPTION
In a previous PR, I added regtest for litecoin where the port was 19443. We've had to modify configurations in other applications because this port defaults from the regtest port that LND expects (which is 18443)