### PR TITLE
Fix/litecoin port

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -89,7 +89,7 @@ var litecoinSimNetParams = litecoinNetParams{
 // regtest on ltc, however litecoind/ltcd has param information for this setup
 var litecoinRegTestNetParams = litecoinNetParams{
 	Params:   &litecoinCfg.RegressionNetParams,
-	rpcPort:  "18334",
+	rpcPort:  "19334",
 	CoinType: keychain.CoinTypeTestnet,
 }
 

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -319,7 +319,9 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 					if cfg.Bitcoin.Active && cfg.Bitcoin.RegTest {
 						rpcPort = 18443
 					} else if cfg.Litecoin.Active && cfg.Litecoin.RegTest {
-						rpcPort = 19334
+						// The default port in ltcd is 19334, however litecoind has a default
+						// rpc port of 19443
+						rpcPort = 19443
 					}
 
 					bitcoindHost = fmt.Sprintf("%v:%d", bitcoindMode.RPCHost, rpcPort)

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -298,9 +298,8 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			if err != nil {
 				return nil, nil, err
 			}
-			// We have absolutely no idea why this this is here however this will change
-			// ports for different networks by 2. This only occurs for bitcoind/litecoind.
-			//
+
+			// This port change only effects bitcoind/litecoind on testnet/simnet/mainnet
 			// ex: 18444 will become 18442
 			rpcPort -= 2
 
@@ -315,13 +314,11 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 				conn, err := net.Dial("tcp", bitcoindHost)
 				if err != nil || conn == nil {
 
-					// For Regtest we will set the ports in accordance to the chainparams for
-					// the specified network
+					// For Regtest we will set the ports explicitly as the port change above
+					// only works for simnet, testnet, mainnet
 					if cfg.Bitcoin.Active && cfg.Bitcoin.RegTest {
 						rpcPort = 18443
 					} else if cfg.Litecoin.Active && cfg.Litecoin.RegTest {
-						// The default port in ltcd is 19334, however litecoind has different
-						// default port set to 19443
 						rpcPort = 19443
 					}
 

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -298,14 +298,15 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			if err != nil {
 				return nil, nil, err
 			}
-			// We have absolutely no idea why this was a good idea however this will
-			// change ports for different networks by 2.
+			// We have absolutely no idea why this this is here however this will change
+			// ports for different networks by 2. This only occurs for bitcoind/litecoind.
+			//
 			// ex: 18444 will become 18442
 			rpcPort -= 2
 
 			// Set the bitcoindHost here so that we can test if the connection works
 			// in the case of regtest. If the connection is bad then we will attempt
-			// use a different port for the host
+			// to use a different port for the host
 			bitcoindHost = fmt.Sprintf("%v:%d", bitcoindMode.RPCHost, rpcPort)
 
 			if (cfg.Bitcoin.Active && cfg.Bitcoin.RegTest) ||
@@ -319,8 +320,8 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 					if cfg.Bitcoin.Active && cfg.Bitcoin.RegTest {
 						rpcPort = 18443
 					} else if cfg.Litecoin.Active && cfg.Litecoin.RegTest {
-						// The default port in ltcd is 19334, however litecoind has a default
-						// rpc port of 19443
+						// The default port in ltcd is 19334, however litecoind has different
+						// default port set to 19443
 						rpcPort = 19443
 					}
 


### PR DESCRIPTION
This PR fixes litecoin regtest port issues on lnd. Right now regtest is currently broken because of port assignment for `litecoind` in chainregistry.

LTCD regtest port: 19334
Litecoind regtest port: 19443

Litecoind Port: https://github.com/litecoin-project/litecoin/blob/master/src/chainparamsbase.cpp#L61

I've decided to stick to using LTCD port params for `chainparams` because a lot of the configurations are being pulled from ltcd. LND already overrides ports for bitcoind during `chainregistry` so we now change the port to 19443 at this spot.